### PR TITLE
[DABOM-143] 사용량 저장 및 실시간 전송 Producer 구현

### DIFF
--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
@@ -3,6 +3,7 @@ package com.project.domain.usage.infra.messaging;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import com.project.domain.usage.service.port.UsagePersistEventPublisher;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.usage.UsagePersistPayload;
 
@@ -12,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UsagePersistKafkaProducer {
+public class UsagePersistKafkaProducer implements UsagePersistEventPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
@@ -21,6 +21,9 @@ public class UsagePersistKafkaProducer {
 
         kafkaTemplate.send("usage-persist", envelope);
 
-        log.info("Published UsagePersist event: {} (Family: {})", envelope.eventId(), payload.familyId());
+        log.info(
+                "Published UsagePersist event: {} (Family: {})",
+                envelope.eventId(),
+                payload.familyId());
     }
 }

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
@@ -17,10 +17,13 @@ public class UsagePersistKafkaProducer implements UsagePersistEventPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    public void publish(UsagePersistPayload payload) {
-        EventEnvelope<UsagePersistPayload> envelope = EventEnvelope.of("USAGE_PERSIST", payload);
+    private static final String TOPIC = "usage-persist";
+    private static final String EVENT_TYPE = "USAGE_PERSIST";
 
-        kafkaTemplate.send("usage-persist", envelope);
+    public void publish(UsagePersistPayload payload) {
+        EventEnvelope<UsagePersistPayload> envelope = EventEnvelope.of(EVENT_TYPE, payload);
+
+        kafkaTemplate.send(TOPIC, envelope);
 
         log.info(
                 "Published UsagePersist event: {} (Family: {})",

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaProducer.java
@@ -1,0 +1,26 @@
+package com.project.domain.usage.infra.messaging;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsagePersistPayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsagePersistKafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publish(UsagePersistPayload payload) {
+        EventEnvelope<UsagePersistPayload> envelope = EventEnvelope.of("USAGE_PERSIST", payload);
+
+        kafkaTemplate.send("usage-persist", envelope);
+
+        log.info("Published UsagePersist event: {} (Family: {})", envelope.eventId(), payload.familyId());
+    }
+}

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
@@ -21,6 +21,9 @@ public class UsageRealtimeKafkaProducer {
 
         kafkaTemplate.send("usage-realtime", envelope);
 
-        log.debug("Published UsageRealtime event: {} (Family: {})", envelope.eventId(), payload.familyId());
+        log.debug(
+                "Published UsageRealtime event: {} (Family: {})",
+                envelope.eventId(),
+                payload.familyId());
     }
 }

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
@@ -17,10 +17,13 @@ public class UsageRealtimeKafkaProducer implements UsageRealtimeEventPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    public void publish(UsageRealtimePayload payload) {
-        EventEnvelope<UsageRealtimePayload> envelope = EventEnvelope.of("USAGE_REALTIME", payload);
+    private static final String TOPIC = "usage-realtime";
+    private static final String EVENT_TYPE = "USAGE_REALTIME";
 
-        kafkaTemplate.send("usage-realtime", envelope);
+    public void publish(UsageRealtimePayload payload) {
+        EventEnvelope<UsageRealtimePayload> envelope = EventEnvelope.of(EVENT_TYPE, payload);
+
+        kafkaTemplate.send(TOPIC, envelope);
 
         log.debug(
                 "Published UsageRealtime event: {} (Family: {})",

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
@@ -1,9 +1,9 @@
 package com.project.domain.usage.infra.messaging;
 
-import com.project.domain.usage.service.port.UsageRealtimeEventPublisher;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import com.project.domain.usage.service.port.UsageRealtimeEventPublisher;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.usage.UsageRealtimePayload;
 

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
@@ -1,0 +1,26 @@
+package com.project.domain.usage.infra.messaging;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsageRealtimePayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsageRealtimeKafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publish(UsageRealtimePayload payload) {
+        EventEnvelope<UsageRealtimePayload> envelope = EventEnvelope.of("USAGE_REALTIME", payload);
+
+        kafkaTemplate.send("usage-realtime", envelope);
+
+        log.debug("Published UsageRealtime event: {} (Family: {})", envelope.eventId(), payload.familyId());
+    }
+}

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageRealtimeKafkaProducer.java
@@ -1,5 +1,6 @@
 package com.project.domain.usage.infra.messaging;
 
+import com.project.domain.usage.service.port.UsageRealtimeEventPublisher;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UsageRealtimeKafkaProducer {
+public class UsageRealtimeKafkaProducer implements UsageRealtimeEventPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 

--- a/src/main/java/com/project/domain/usage/service/port/UsagePersistEventPublisher.java
+++ b/src/main/java/com/project/domain/usage/service/port/UsagePersistEventPublisher.java
@@ -1,0 +1,7 @@
+package com.project.domain.usage.service.port;
+
+import com.project.global.event.dto.usage.UsagePersistPayload;
+
+public interface UsagePersistEventPublisher {
+    void publish(UsagePersistPayload payload);
+}

--- a/src/main/java/com/project/domain/usage/service/port/UsageRealtimeEventPublisher.java
+++ b/src/main/java/com/project/domain/usage/service/port/UsageRealtimeEventPublisher.java
@@ -1,0 +1,7 @@
+package com.project.domain.usage.service.port;
+
+import com.project.global.event.dto.usage.UsageRealtimePayload;
+
+public interface UsageRealtimeEventPublisher {
+    void publish(UsageRealtimePayload payload);
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #2 
- jira: DABOM-143

---

## 🎯 목적

사용량 처리 결과 저장(UsagePersist) 및 실시간 대시보드 전송(UsageRealtime)을 위한 Kafka Producer 구현

## 📝 변경 사항

- UsagePersistKafkaProducer구현 (DB 저장용)
- UsageRealtimeKafkaProducer구현 (실시간 대시보드용)

-

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|  usage  |            |         |            |        |   x  |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
public void publish(UsagePersistPayload payload) {
        EventEnvelope<UsagePersistPayload> envelope = EventEnvelope.of("USAGE_PERSIST", payload);

        kafkaTemplate.send("usage-persist", envelope);

        log.info("Published UsagePersist event: {} (Family: {})", envelope.eventId(), payload.familyId());
    }
```

```java
public void publish(UsageRealtimePayload payload) {
        EventEnvelope<UsageRealtimePayload> envelope = EventEnvelope.of("USAGE_REALTIME", payload);

        kafkaTemplate.send("usage-realtime", envelope);

        log.debug("Published UsageRealtime event: {} (Family: {})", envelope.eventId(), payload.familyId());
    }
```

## 💬 리뷰어에게

추후 KafkaConstants 리팩토링 시 문자열 하드코딩 부분은 수정 예정입니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

Kafka Topic & Consumer Group ID Name 참고
