### PR TITLE
[DABOM-144] 알림 전송 Producer 구현

### DIFF
--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaProducer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaProducer.java
@@ -23,26 +23,18 @@ public class NotificationKafkaProducer implements NotificationEventPublisher {
 
     public void publish(NotificationPayload payload) {
 
-        var extraction =
+        String subType =
                 switch (payload) {
-                    case QuotaUpdatedPayload p -> new Extraction("QUOTA_UPDATED", p.familyId());
-                    case CustomerBlockedPayload p ->
-                            new Extraction("CUSTOMER_BLOCKED", p.familyId());
-                    case ThresholdAlertPayload p -> new Extraction("THRESHOLD_ALERT", p.familyId());
+                    case QuotaUpdatedPayload p -> "QUOTA_UPDATED";
+                    case CustomerBlockedPayload p -> "CUSTOMER_BLOCKED";
+                    case ThresholdAlertPayload p -> "THRESHOLD_ALERT";
                 };
 
         EventEnvelope<NotificationPayload> envelope =
-                EventEnvelope.of("NOTIFICATION", extraction.subType(), payload);
+                EventEnvelope.of("NOTIFICATION", subType, payload);
 
         kafkaTemplate.send(TOPIC, envelope);
 
-        log.info(
-                "Published Notification event: {} (Type: {}, Family: {})",
-                envelope.eventId(),
-                extraction.subType(),
-                extraction.familyId());
+        log.info("Published Notification event: {} (Type: {})", envelope.eventId(), subType);
     }
-
-    // 내부 처리를 위한 임시 Record
-    private record Extraction(String subType, Long familyId) {}
 }

--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaProducer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaProducer.java
@@ -1,0 +1,47 @@
+package com.project.domain.notification.infra.messaging;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.notification.CustomerBlockedPayload;
+import com.project.global.event.dto.notification.NotificationPayload;
+import com.project.global.event.dto.notification.QuotaUpdatedPayload;
+import com.project.global.event.dto.notification.ThresholdAlertPayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationKafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private static final String TOPIC = "notification-events";
+
+    public void publish(NotificationPayload payload) {
+
+        var extraction =
+                switch (payload) {
+                    case QuotaUpdatedPayload p -> new Extraction("QUOTA_UPDATED", p.familyId());
+                    case CustomerBlockedPayload p ->
+                            new Extraction("CUSTOMER_BLOCKED", p.familyId());
+                    case ThresholdAlertPayload p -> new Extraction("THRESHOLD_ALERT", p.familyId());
+                };
+
+        EventEnvelope<NotificationPayload> envelope =
+                EventEnvelope.of("NOTIFICATION", extraction.subType(), payload);
+
+        kafkaTemplate.send(TOPIC, envelope);
+
+        log.info(
+                "Published Notification event: {} (Type: {}, Family: {})",
+                envelope.eventId(),
+                extraction.subType(),
+                extraction.familyId());
+    }
+
+    // 내부 처리를 위한 임시 Record
+    private record Extraction(String subType, Long familyId) {}
+}

--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaProducer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaProducer.java
@@ -3,6 +3,7 @@ package com.project.domain.notification.infra.messaging;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import com.project.domain.notification.service.port.NotificationEventPublisher;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.notification.CustomerBlockedPayload;
 import com.project.global.event.dto.notification.NotificationPayload;
@@ -15,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class NotificationKafkaProducer {
+public class NotificationKafkaProducer implements NotificationEventPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private static final String TOPIC = "notification-events";

--- a/src/main/java/com/project/domain/notification/service/port/NotificationEventPublisher.java
+++ b/src/main/java/com/project/domain/notification/service/port/NotificationEventPublisher.java
@@ -1,0 +1,8 @@
+package com.project.domain.notification.service.port;
+
+import com.project.global.event.dto.notification.NotificationPayload;
+
+public interface NotificationEventPublisher {
+
+    void publish(NotificationPayload payload);
+}

--- a/src/main/java/com/project/global/event/dto/EventEnvelope.java
+++ b/src/main/java/com/project/global/event/dto/EventEnvelope.java
@@ -37,4 +37,13 @@ public record EventEnvelope<T>(
         return new EventEnvelope<>(
                 UUID.randomUUID().toString(), eventType, null, LocalDateTime.now(), payload);
     }
+
+    public static <T> EventEnvelope<T> of(String eventType, String subType, T payload) {
+        return new EventEnvelope<>(
+                UUID.randomUUID().toString(),
+                eventType,
+                subType, // 지정한 값 삽입
+                LocalDateTime.now(),
+                payload);
+    }
 }


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #3 
- jira: DABOM-144

---

## 🎯 목적

정책 위반 및 사용량 임계치 초과 시 클라이언트에게 알림을 전송하기 위한 Kafka Producer 구현 (Notification 도메인 분리)

## 📝 변경 사항

- NotificationKafkaProducer 구현 (com.project.domain.notification)
- EventEnvelope.of(eventType, subType, payload) 팩토리 메소드 추가 (다형성 지원)
- Java 21 Switch Expression을 활용한 Payload 타입 분기 처리

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|   notification  |            |         |            |        |   x   |   x    |

---

## 🖥️ 주요 코드 설명
Java 21 Pattern Matching for Switch
```java
// Payload 타입에 따라 subType을 자동 추출
String subType = switch (payload) {
    case QuotaUpdatedPayload p -> "QUOTA_UPDATED";
    case CustomerBlockedPayload p -> "CUSTOMER_BLOCKED";
    case ThresholdAlertPayload p -> "THRESHOLD_ALERT";
};
```

## 💬 리뷰어에게

- NotificationPayload는 Sealed Interface이므로, switch 문에서 모든 타입을 커버해야 하며 default가 불필요합니다. 
- EventEnvelope에 subType 필드를 명시적으로 채워주어야 Consumer 측 Jackson 역직렬화가 정상 동작해서 추가했습니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- [Java 21 Pattern Matching for Switch 공식 문서](https://openjdk.org/jeps/441)
