### PR TITLE
[DABOM-146] policy-updated 컨슈머 구현

### DIFF
--- a/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
@@ -13,6 +13,8 @@ public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long
 
     List<FamilyMember> findAllByFamilyIdAndDeletedAtIsNull(Long familyId);
 
+    boolean existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(Long familyId, Long customerId);
+
     @Query("select f.role from FamilyMember f where f.customerId = :customerId")
     RoleType findRoleById(Long customerId);
 }

--- a/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
@@ -11,6 +11,8 @@ import com.project.domain.family.entity.FamilyMember;
 public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long> {
     List<FamilyMember> findAllByFamilyId(Long familyId);
 
+    List<FamilyMember> findAllByFamilyIdAndDeletedAtIsNull(Long familyId);
+
     @Query("select f.role from FamilyMember f where f.customerId = :customerId")
     RoleType findRoleById(Long customerId);
 }

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -1,0 +1,120 @@
+package com.project.domain.policy.infra.messaging;
+
+import java.time.Duration;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.policy.PolicyUpdatedPayload;
+import com.project.global.util.RedisKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PolicyKafkaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, String> familyStringRedisTemplate;
+    private final RedisKeyGenerator redisKeyGenerator;
+
+    // 중복 이벤트 키 TTL 설정 (기본값: 3600초)
+    @Value("${app.kafka.dedup.policy-ttl-seconds}")
+    private long dedupTtlSeconds;
+
+    @KafkaListener(topics = "policy-updated", groupId = "policy-group")
+    public void consume(ConsumerRecord<String, String> record) {
+        try {
+            // 역직렬화
+            EventEnvelope<PolicyUpdatedPayload> envelope =
+                    objectMapper.readValue(record.value(), new TypeReference<>() {});
+
+            // payload가 없으면 로그 출력 후 종료
+            PolicyUpdatedPayload payload = envelope.payload();
+            if (payload == null) {
+                log.warn("policy-updated payload is null. recordKey={}", record.key());
+                return;
+            }
+
+            // eventId가 비어있으면 멱등 처리 불가라서 로그 출력 후 종료
+            String eventId = envelope.eventId();
+            if (eventId == null || eventId.isBlank()) {
+                log.warn(
+                        "policy-updated eventId is empty. familyId={}, customerId={}, policyKey={}",
+                        payload.familyId(),
+                        payload.targetCustomerId(),
+                        payload.policyKey());
+                return;
+            }
+
+            // 중복 방지: 이미 키가 있으면 중복 이벤트로 판단하고 스킵
+            String dedupKey = "event:dedup:policy:" + eventId;
+            Boolean firstSeen =
+                    familyStringRedisTemplate
+                            .opsForValue()
+                            .setIfAbsent(dedupKey, "1", Duration.ofSeconds(dedupTtlSeconds));
+            if (!Boolean.TRUE.equals(firstSeen)) {
+                log.info("Skip duplicated policy-updated event. eventId={}", eventId);
+                return;
+            }
+
+            // payload 필수값 검증
+            // 누락시 잘못된 이벤트로 간주하고 종료
+            if (payload.familyId() == null
+                    || payload.targetCustomerId() == null
+                    || payload.policyKey() == null
+                    || payload.policyKey().isBlank()) {
+                log.warn(
+                        "Invalid policy-updated payload. eventId={}, familyId={}, customerId={},"
+                                + " policyKey={}",
+                        eventId,
+                        payload.familyId(),
+                        payload.targetCustomerId(),
+                        payload.policyKey());
+                return;
+            }
+
+            // constraint 키 생성
+            String constraintsKey =
+                    redisKeyGenerator.generateFamilyCustomerConstraintsKey(
+                            payload.familyId(), payload.targetCustomerId());
+
+            // 정책 반영
+            // newValue가 비어있으면 해당 policyKey 필드를 삭제 (정책 해제)
+            String newValue = payload.newValue();
+            if (newValue == null || newValue.isBlank()) {
+                familyStringRedisTemplate.opsForHash().delete(constraintsKey, payload.policyKey());
+                log.info(
+                        "Removed constraint. eventId={}, key={}, field={}",
+                        eventId,
+                        constraintsKey,
+                        payload.policyKey());
+                return;
+            }
+
+            // newValue가 있으면 해당 policyKey 필드를 새 값으로 저장 (정책 갱신)
+            familyStringRedisTemplate
+                    .opsForHash()
+                    .put(constraintsKey, payload.policyKey(), newValue);
+            log.info(
+                    "Updated constraint. eventId={}, key={}, field={}, value={}",
+                    eventId,
+                    constraintsKey,
+                    payload.policyKey(),
+                    newValue);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse policy-updated payload", e);
+        } catch (Exception e) {
+            log.error("Failed to handle policy-updated event", e);
+        }
+    }
+}

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -33,7 +33,6 @@ public class PolicyKafkaConsumer {
     private final RedisKeyGenerator redisKeyGenerator;
     private final FamilyMemberRepository familyMemberRepository;
 
-    // 중복 이벤트 키 TTL 설정 (기본값: 3600초)
     @Value("${app.kafka.dedup.policy-ttl-seconds}")
     private long dedupTtlSeconds;
 
@@ -43,93 +42,69 @@ public class PolicyKafkaConsumer {
             // 역직렬화
             EventEnvelope<PolicyUpdatedPayload> envelope =
                     objectMapper.readValue(record.value(), new TypeReference<>() {});
-
-            // payload가 없으면 로그 출력 후 종료
             PolicyUpdatedPayload payload = envelope.payload();
-            if (payload == null) {
-                log.warn("policy-updated payload is null. recordKey={}", record.key());
-                return;
-            }
-
-            // eventId가 비어있으면 멱등 처리 불가라서 로그 출력 후 종료
             String eventId = envelope.eventId();
-            if (eventId == null || eventId.isBlank()) {
-                log.warn(
-                        "policy-updated eventId is empty. familyId={}, customerId={}, policyKey={}",
-                        payload.familyId(),
-                        payload.targetCustomerId(),
-                        payload.policyKey());
+
+            // payload/eventId/필수값 검증
+            if (!isValidPayload(payload, eventId, record)) {
                 return;
             }
 
-            // 중복 방지: 이미 키가 있으면 중복 이벤트로 판단하고 스킵
-            String dedupKey = "event:dedup:policy:" + eventId;
-            Boolean firstSeen =
-                    familyStringRedisTemplate
-                            .opsForValue()
-                            .setIfAbsent(dedupKey, "1", Duration.ofSeconds(dedupTtlSeconds));
-            if (!Boolean.TRUE.equals(firstSeen)) {
-                log.info("Skip duplicated policy-updated event. eventId={}", eventId);
+            // 중복 이벤트는 스킵
+            if (isDuplicated(eventId)) {
                 return;
             }
 
-            // payload 필수값 검증
-            // 누락시 잘못된 이벤트로 간주하고 종료
-            if (payload.familyId() == null
-                    || payload.policyKey() == null
-                    || payload.policyKey().isBlank()) {
-                log.warn(
-                        "Invalid policy-updated payload. eventId={}, familyId={}, customerId={},"
-                                + " policyKey={}",
-                        eventId,
-                        payload.familyId(),
-                        payload.targetCustomerId(),
-                        payload.policyKey());
-                return;
-            }
-
+            String policyKey = payload.policyKey();
             String newValue = payload.newValue();
             Long targetCustomerId = payload.targetCustomerId();
-            if (newValue != null && !newValue.isBlank()) {
-                if (!isValidPolicyValue(payload.policyKey(), newValue)) {
-                    log.warn(
-                            "Invalid policy value. eventId={}, familyId={}, customerId={},"
-                                    + " field={}, value={}",
-                            eventId,
-                            payload.familyId(),
-                            targetCustomerId,
-                            payload.policyKey(),
-                            newValue);
-                    return;
-                }
+
+            if (!isAllowedPolicyKey(policyKey)) {
+                log.warn(
+                        "Invalid policy key. eventId={}, familyId={}, customerId={}, field={}",
+                        eventId,
+                        payload.familyId(),
+                        targetCustomerId,
+                        policyKey);
+                return;
             }
 
-            // targetCustomerId != null: 해당하는 customer 정책 적용
+            // newValue가 있는 경우에만 값 형식 검증
+            if (newValue != null
+                    && !newValue.isBlank()
+                    && !isValidPolicyValue(policyKey, newValue)) {
+                log.warn(
+                        "Invalid policy value. eventId={}, familyId={}, customerId={}, field={},"
+                                + " value={}",
+                        eventId,
+                        payload.familyId(),
+                        targetCustomerId,
+                        policyKey,
+                        newValue);
+                return;
+            }
+
+            // targetCustomerId가 있으면 해당 customer만 반영
             if (targetCustomerId != null) {
-                String constraintsKey =
-                        redisKeyGenerator.generateFamilyCustomerConstraintsKey(
-                                payload.familyId(), targetCustomerId);
-                applyConstraint(constraintsKey, payload.policyKey(), newValue);
+                applyConstraintToCustomer(
+                        payload.familyId(), targetCustomerId, policyKey, newValue);
                 log.info(
                         "Updated customer constraint. eventId={}, familyId={}, customerId={},"
                                 + " field={}, value={}",
                         eventId,
                         payload.familyId(),
                         targetCustomerId,
-                        payload.policyKey(),
+                        policyKey,
                         newValue);
                 return;
             }
 
-            // targetCustomerId == null: family 전체 정책 -> active customer 전원에게 반영
+            // targetCustomerId가 없으면 family 전체(active customer)에게 반영
             List<FamilyMember> customers =
                     familyMemberRepository.findAllByFamilyIdAndDeletedAtIsNull(payload.familyId());
-
             for (FamilyMember customer : customers) {
-                String constraintsKey =
-                        redisKeyGenerator.generateFamilyCustomerConstraintsKey(
-                                payload.familyId(), customer.getCustomerId());
-                applyConstraint(constraintsKey, payload.policyKey(), newValue);
+                applyConstraintToCustomer(
+                        payload.familyId(), customer.getCustomerId(), policyKey, newValue);
             }
 
             log.info(
@@ -138,7 +113,7 @@ public class PolicyKafkaConsumer {
                     eventId,
                     payload.familyId(),
                     customers.size(),
-                    payload.policyKey(),
+                    policyKey,
                     newValue);
         } catch (JsonProcessingException e) {
             log.error("Failed to parse policy-updated payload", e);
@@ -147,21 +122,97 @@ public class PolicyKafkaConsumer {
         }
     }
 
+    private boolean isValidPayload(
+            PolicyUpdatedPayload payload, String eventId, ConsumerRecord<String, String> record) {
+        // payload가 없으면 종료
+        if (payload == null) {
+            log.warn("policy-updated payload is null. recordKey={}", record.key());
+            return false;
+        }
+
+        // eventId가 없으면 멱등 처리 불가
+        if (eventId == null || eventId.isBlank()) {
+            log.warn(
+                    "policy-updated eventId is empty. familyId={}, customerId={}, policyKey={}",
+                    payload.familyId(),
+                    payload.targetCustomerId(),
+                    payload.policyKey());
+            return false;
+        }
+
+        // familyId/policyKey는 필수값
+        if (payload.familyId() == null
+                || payload.policyKey() == null
+                || payload.policyKey().isBlank()) {
+            log.warn(
+                    "Invalid policy-updated payload. eventId={}, familyId={}, customerId={},"
+                            + " policyKey={}",
+                    eventId,
+                    payload.familyId(),
+                    payload.targetCustomerId(),
+                    payload.policyKey());
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isDuplicated(String eventId) {
+        // dedup 키가 이미 있으면 중복 이벤트로 판단
+        String dedupKey = "event:dedup:policy:" + eventId;
+        Boolean firstSeen =
+                familyStringRedisTemplate
+                        .opsForValue()
+                        .setIfAbsent(dedupKey, "1", Duration.ofSeconds(dedupTtlSeconds));
+
+        if (!Boolean.TRUE.equals(firstSeen)) {
+            log.info("Skip duplicated policy-updated event. eventId={}", eventId);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void applyConstraintToCustomer(
+            Long familyId, Long customerId, String policyKey, String newValue) {
+        // customer 단위 constraints 키 생성
+        String constraintsKey =
+                redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
+        applyConstraint(constraintsKey, policyKey, newValue);
+    }
+
     private void applyConstraint(String constraintsKey, String policyKey, String newValue) {
-        // newValue가 비어있으면 해당 policyKey 필드를 삭제 (정책 해제)
+        // newValue가 비어있으면 정책 해제(HDEL)
         if (newValue == null || newValue.isBlank()) {
             familyStringRedisTemplate.opsForHash().delete(constraintsKey, policyKey);
             return;
         }
-        // newValue가 있으면 해당 policyKey 필드를 새 값으로 저장 (정책 갱신)
+        // newValue가 있으면 정책 갱신(HSET)
         familyStringRedisTemplate.opsForHash().put(constraintsKey, policyKey, newValue);
     }
 
-    // value 값 검증
-    private boolean isValidPolicyValue(String policyKey, String newValue) {
+    private boolean isAllowedPolicyKey(String policyKey) {
+        // 삭제/갱신 공통으로 허용된 정책 키인지 먼저 검증
         if (policyKey == null || policyKey.isBlank()) {
             return false;
         }
+        if ("THROTTLE:SPEED".equals(policyKey)) {
+            return true;
+        }
+        if ("BLOCK:ACCESS".equals(policyKey) || policyKey.startsWith("BLOCK:APP:")) {
+            return true;
+        }
+        if ("BLOCK:TIME:START".equals(policyKey) || "BLOCK:TIME:END".equals(policyKey)) {
+            return true;
+        }
+        if (policyKey.startsWith("LIMIT:DATA:")) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isValidPolicyValue(String policyKey, String newValue) {
+        // 정책 키별 value 형식 검증
         if ("THROTTLE:SPEED".equals(policyKey)) {
             return isPositiveLong(newValue);
         }
@@ -174,12 +225,11 @@ public class PolicyKafkaConsumer {
         if (policyKey.startsWith("LIMIT:DATA:")) {
             return isPositiveLong(newValue);
         }
-
-        // 알 수 없는 정책 키는 v1에서는 허용하지 않음
         return false;
     }
 
     private boolean isPositiveLong(String value) {
+        // 양의 정수 검증
         try {
             return Long.parseLong(value) > 0;
         } catch (NumberFormatException e) {
@@ -188,6 +238,7 @@ public class PolicyKafkaConsumer {
     }
 
     private boolean isValidHhmm(String value) {
+        // HHMM 형식 + 시/분 범위 검증
         if (!HHMM_PATTERN.matcher(value).matches()) {
             return false;
         }

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -2,6 +2,8 @@ package com.project.domain.policy.infra.messaging;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -27,6 +29,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PolicyKafkaConsumer {
     private static final Pattern HHMM_PATTERN = Pattern.compile("^\\d{4}$");
+    private static final Predicate<String> BINARY_FLAG_VALIDATOR =
+            value -> "1".equals(value) || "0".equals(value);
+    private static final Predicate<String> POSITIVE_LONG_VALIDATOR =
+            PolicyKafkaConsumer::isPositiveLongValue;
+    private static final Predicate<String> HHMM_VALIDATOR = PolicyKafkaConsumer::isValidHhmmValue;
+
+    private static final Map<String, Predicate<String>> EXACT_VALUE_VALIDATORS =
+            Map.of(
+                    "THROTTLE:SPEED", POSITIVE_LONG_VALIDATOR,
+                    "BLOCK:ACCESS", BINARY_FLAG_VALIDATOR,
+                    "BLOCK:TIME:START", HHMM_VALIDATOR,
+                    "BLOCK:TIME:END", HHMM_VALIDATOR);
+
+    private static final Map<String, Predicate<String>> PREFIX_VALUE_VALIDATORS =
+            Map.of("BLOCK:APP:", BINARY_FLAG_VALIDATOR, "LIMIT:DATA:", POSITIVE_LONG_VALIDATOR);
 
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> familyStringRedisTemplate;
@@ -211,39 +228,38 @@ public class PolicyKafkaConsumer {
         if (policyKey == null || policyKey.isBlank()) {
             return false;
         }
-        if ("THROTTLE:SPEED".equals(policyKey)) {
+        if (EXACT_VALUE_VALIDATORS.containsKey(policyKey)) {
             return true;
         }
-        if ("BLOCK:ACCESS".equals(policyKey) || policyKey.startsWith("BLOCK:APP:")) {
-            return true;
-        }
-        if ("BLOCK:TIME:START".equals(policyKey) || "BLOCK:TIME:END".equals(policyKey)) {
-            return true;
-        }
-        if (policyKey.startsWith("LIMIT:DATA:")) {
-            return true;
-        }
-        return false;
+        return findPrefixValidator(policyKey) != null;
     }
 
     private boolean isValidPolicyValue(String policyKey, String newValue) {
         // 정책 키별 value 형식 검증
-        if ("THROTTLE:SPEED".equals(policyKey)) {
-            return isPositiveLong(newValue);
+        if (policyKey == null || policyKey.isBlank()) {
+            return false;
         }
-        if ("BLOCK:ACCESS".equals(policyKey) || policyKey.startsWith("BLOCK:APP:")) {
-            return "1".equals(newValue) || "0".equals(newValue);
+        Predicate<String> exactValidator = EXACT_VALUE_VALIDATORS.get(policyKey);
+        if (exactValidator != null) {
+            return exactValidator.test(newValue);
         }
-        if ("BLOCK:TIME:START".equals(policyKey) || "BLOCK:TIME:END".equals(policyKey)) {
-            return isValidHhmm(newValue);
-        }
-        if (policyKey.startsWith("LIMIT:DATA:")) {
-            return isPositiveLong(newValue);
+        Predicate<String> prefixValidator = findPrefixValidator(policyKey);
+        if (prefixValidator != null) {
+            return prefixValidator.test(newValue);
         }
         return false;
     }
 
-    private boolean isPositiveLong(String value) {
+    private Predicate<String> findPrefixValidator(String policyKey) {
+        for (Map.Entry<String, Predicate<String>> entry : PREFIX_VALUE_VALIDATORS.entrySet()) {
+            if (policyKey.startsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static boolean isPositiveLongValue(String value) {
         // 양의 정수 검증
         try {
             return Long.parseLong(value) > 0;
@@ -252,7 +268,7 @@ public class PolicyKafkaConsumer {
         }
     }
 
-    private boolean isValidHhmm(String value) {
+    private static boolean isValidHhmmValue(String value) {
         // HHMM 형식 + 시/분 범위 검증
         if (!HHMM_PATTERN.matcher(value).matches()) {
             return false;

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -3,9 +3,9 @@ package com.project.domain.policy.infra.messaging;
 import java.time.Duration;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -1,25 +1,15 @@
 package com.project.domain.policy.infra.messaging;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.domain.family.entity.FamilyMember;
-import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.policy.service.PolicyConstraintSyncService;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.policy.PolicyUpdatedPayload;
-import com.project.global.util.RedisKeyGenerator;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,255 +18,20 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class PolicyKafkaConsumer {
-    private static final Pattern HHMM_PATTERN = Pattern.compile("^\\d{4}$");
-    private static final Predicate<String> BINARY_FLAG_VALIDATOR =
-            value -> "1".equals(value) || "0".equals(value);
-    private static final Predicate<String> POSITIVE_LONG_VALIDATOR =
-            PolicyKafkaConsumer::isPositiveLongValue;
-    private static final Predicate<String> HHMM_VALIDATOR = PolicyKafkaConsumer::isValidHhmmValue;
-
-    private static final Map<String, Predicate<String>> EXACT_VALUE_VALIDATORS =
-            Map.of(
-                    "THROTTLE:SPEED", POSITIVE_LONG_VALIDATOR,
-                    "BLOCK:ACCESS", BINARY_FLAG_VALIDATOR,
-                    "BLOCK:TIME:START", HHMM_VALIDATOR,
-                    "BLOCK:TIME:END", HHMM_VALIDATOR);
-
-    private static final Map<String, Predicate<String>> PREFIX_VALUE_VALIDATORS =
-            Map.of("BLOCK:APP:", BINARY_FLAG_VALIDATOR, "LIMIT:DATA:", POSITIVE_LONG_VALIDATOR);
 
     private final ObjectMapper objectMapper;
-    private final RedisTemplate<String, String> familyStringRedisTemplate;
-    private final RedisKeyGenerator redisKeyGenerator;
-    private final FamilyMemberRepository familyMemberRepository;
-
-    @Value("${app.kafka.dedup.policy-ttl-seconds}")
-    private long dedupTtlSeconds;
+    private final PolicyConstraintSyncService policyConstraintSyncService;
 
     @KafkaListener(topics = "policy-updated", groupId = "dabom-processor-usage-policy-group")
     public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
-            // 역직렬화
             EventEnvelope<PolicyUpdatedPayload> envelope =
                     objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
-            PolicyUpdatedPayload payload = envelope.payload();
-            String eventId = envelope.eventId();
-
-            // payload/eventId/필수값 검증
-            if (!isValidPayload(payload, eventId, consumerRecord)) {
-                return;
-            }
-
-            // 중복 이벤트는 스킵
-            if (isDuplicated(eventId)) {
-                return;
-            }
-
-            String policyKey = payload.policyKey();
-            String newValue = payload.newValue();
-            Long targetCustomerId = payload.targetCustomerId();
-
-            if (!isAllowedPolicyKey(policyKey)) {
-                log.warn(
-                        "Invalid policy key. eventId={}, familyId={}, customerId={}, field={}",
-                        eventId,
-                        payload.familyId(),
-                        targetCustomerId,
-                        policyKey);
-                return;
-            }
-
-            // newValue가 있는 경우에만 값 형식 검증
-            if (newValue != null
-                    && !newValue.isBlank()
-                    && !isValidPolicyValue(policyKey, newValue)) {
-                log.warn(
-                        "Invalid policy value. eventId={}, familyId={}, customerId={}, field={},"
-                                + " value={}",
-                        eventId,
-                        payload.familyId(),
-                        targetCustomerId,
-                        policyKey,
-                        newValue);
-                return;
-            }
-
-            // targetCustomerId가 있으면 해당 customer만 반영
-            if (targetCustomerId != null) {
-                // family-customer 소속 관계 검증
-                boolean isFamilyMember =
-                        familyMemberRepository.existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(
-                                payload.familyId(), targetCustomerId);
-                if (!isFamilyMember) {
-                    log.warn(
-                            "Skip policy update due to invalid family-customer relation."
-                                    + " eventId={}, familyId={}, customerId={}, field={}",
-                            eventId,
-                            payload.familyId(),
-                            targetCustomerId,
-                            policyKey);
-                    return;
-                }
-
-                applyConstraintToCustomer(
-                        payload.familyId(), targetCustomerId, policyKey, newValue);
-                log.info(
-                        "Updated customer constraint. eventId={}, familyId={}, customerId={},"
-                                + " field={}, value={}",
-                        eventId,
-                        payload.familyId(),
-                        targetCustomerId,
-                        policyKey,
-                        newValue);
-                return;
-            }
-
-            // targetCustomerId가 없으면 family 전체(active customer)에게 반영
-            List<FamilyMember> customers =
-                    familyMemberRepository.findAllByFamilyIdAndDeletedAtIsNull(payload.familyId());
-            for (FamilyMember customer : customers) {
-                applyConstraintToCustomer(
-                        payload.familyId(), customer.getCustomerId(), policyKey, newValue);
-            }
-
-            log.info(
-                    "Updated family-wide constraint. eventId={}, familyId={}, targetCount={},"
-                            + " field={}, value={}",
-                    eventId,
-                    payload.familyId(),
-                    customers.size(),
-                    policyKey,
-                    newValue);
+            policyConstraintSyncService.sync(envelope, consumerRecord.key());
         } catch (JsonProcessingException e) {
             log.error("Failed to parse policy-updated payload", e);
         } catch (Exception e) {
             log.error("Failed to handle policy-updated event", e);
         }
-    }
-
-    private boolean isValidPayload(
-            PolicyUpdatedPayload payload,
-            String eventId,
-            ConsumerRecord<String, String> consumerRecord) {
-        // payload가 없으면 종료
-        if (payload == null) {
-            log.warn("policy-updated payload is null. recordKey={}", consumerRecord.key());
-            return false;
-        }
-
-        // eventId가 없으면 멱등 처리 불가
-        if (eventId == null || eventId.isBlank()) {
-            log.warn(
-                    "policy-updated eventId is empty. familyId={}, customerId={}, policyKey={}",
-                    payload.familyId(),
-                    payload.targetCustomerId(),
-                    payload.policyKey());
-            return false;
-        }
-
-        // familyId/policyKey는 필수값
-        if (payload.familyId() == null
-                || payload.policyKey() == null
-                || payload.policyKey().isBlank()) {
-            log.warn(
-                    "Invalid policy-updated payload. eventId={}, familyId={}, customerId={},"
-                            + " policyKey={}",
-                    eventId,
-                    payload.familyId(),
-                    payload.targetCustomerId(),
-                    payload.policyKey());
-            return false;
-        }
-
-        return true;
-    }
-
-    private boolean isDuplicated(String eventId) {
-        // dedup 키가 이미 있으면 중복 이벤트로 판단
-        String dedupKey = redisKeyGenerator.generatePolicyEventDedupKey(eventId);
-        Boolean firstSeen =
-                familyStringRedisTemplate
-                        .opsForValue()
-                        .setIfAbsent(dedupKey, "1", Duration.ofSeconds(dedupTtlSeconds));
-
-        if (!Boolean.TRUE.equals(firstSeen)) {
-            log.info("Skip duplicated policy-updated event. eventId={}", eventId);
-            return true;
-        }
-
-        return false;
-    }
-
-    private void applyConstraintToCustomer(
-            Long familyId, Long customerId, String policyKey, String newValue) {
-        // customer 단위 constraints 키 생성
-        String constraintsKey =
-                redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
-        applyConstraint(constraintsKey, policyKey, newValue);
-    }
-
-    private void applyConstraint(String constraintsKey, String policyKey, String newValue) {
-        // newValue가 비어있으면 정책 해제(HDEL)
-        if (newValue == null || newValue.isBlank()) {
-            familyStringRedisTemplate.opsForHash().delete(constraintsKey, policyKey);
-            return;
-        }
-        // newValue가 있으면 정책 갱신(HSET)
-        familyStringRedisTemplate.opsForHash().put(constraintsKey, policyKey, newValue);
-    }
-
-    private boolean isAllowedPolicyKey(String policyKey) {
-        // 삭제/갱신 공통으로 허용된 정책 키인지 먼저 검증
-        if (policyKey == null || policyKey.isBlank()) {
-            return false;
-        }
-        if (EXACT_VALUE_VALIDATORS.containsKey(policyKey)) {
-            return true;
-        }
-        return findPrefixValidator(policyKey) != null;
-    }
-
-    private boolean isValidPolicyValue(String policyKey, String newValue) {
-        // 정책 키별 value 형식 검증
-        if (policyKey == null || policyKey.isBlank()) {
-            return false;
-        }
-        Predicate<String> exactValidator = EXACT_VALUE_VALIDATORS.get(policyKey);
-        if (exactValidator != null) {
-            return exactValidator.test(newValue);
-        }
-        Predicate<String> prefixValidator = findPrefixValidator(policyKey);
-        if (prefixValidator != null) {
-            return prefixValidator.test(newValue);
-        }
-        return false;
-    }
-
-    private Predicate<String> findPrefixValidator(String policyKey) {
-        for (Map.Entry<String, Predicate<String>> entry : PREFIX_VALUE_VALIDATORS.entrySet()) {
-            if (policyKey.startsWith(entry.getKey())) {
-                return entry.getValue();
-            }
-        }
-        return null;
-    }
-
-    private static boolean isPositiveLongValue(String value) {
-        // 양의 정수 검증
-        try {
-            return Long.parseLong(value) > 0;
-        } catch (NumberFormatException e) {
-            return false;
-        }
-    }
-
-    private static boolean isValidHhmmValue(String value) {
-        // HHMM 형식 + 시/분 범위 검증
-        if (!HHMM_PATTERN.matcher(value).matches()) {
-            return false;
-        }
-        int hh = Integer.parseInt(value.substring(0, 2));
-        int mm = Integer.parseInt(value.substring(2, 4));
-        return hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59;
     }
 }

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -86,6 +86,21 @@ public class PolicyKafkaConsumer {
 
             // targetCustomerId가 있으면 해당 customer만 반영
             if (targetCustomerId != null) {
+                // family-customer 소속 관계 검증
+                boolean isFamilyMember =
+                        familyMemberRepository.existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(
+                                payload.familyId(), targetCustomerId);
+                if (!isFamilyMember) {
+                    log.warn(
+                            "Skip policy update due to invalid family-customer relation."
+                                    + " eventId={}, familyId={}, customerId={}, field={}",
+                            eventId,
+                            payload.familyId(),
+                            targetCustomerId,
+                            policyKey);
+                    return;
+                }
+
                 applyConstraintToCustomer(
                         payload.familyId(), targetCustomerId, policyKey, newValue);
                 log.info(

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -155,7 +155,9 @@ public class PolicyKafkaConsumer {
     }
 
     private boolean isValidPayload(
-            PolicyUpdatedPayload payload, String eventId, ConsumerRecord<String, String> consumerRecord) {
+            PolicyUpdatedPayload payload,
+            String eventId,
+            ConsumerRecord<String, String> consumerRecord) {
         // payload가 없으면 종료
         if (payload == null) {
             log.warn("policy-updated payload is null. recordKey={}", consumerRecord.key());

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -54,16 +54,16 @@ public class PolicyKafkaConsumer {
     private long dedupTtlSeconds;
 
     @KafkaListener(topics = "policy-updated", groupId = "dabom-processor-usage-policy-group")
-    public void consume(ConsumerRecord<String, String> record) {
+    public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
             // 역직렬화
             EventEnvelope<PolicyUpdatedPayload> envelope =
-                    objectMapper.readValue(record.value(), new TypeReference<>() {});
+                    objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
             PolicyUpdatedPayload payload = envelope.payload();
             String eventId = envelope.eventId();
 
             // payload/eventId/필수값 검증
-            if (!isValidPayload(payload, eventId, record)) {
+            if (!isValidPayload(payload, eventId, consumerRecord)) {
                 return;
             }
 
@@ -155,10 +155,10 @@ public class PolicyKafkaConsumer {
     }
 
     private boolean isValidPayload(
-            PolicyUpdatedPayload payload, String eventId, ConsumerRecord<String, String> record) {
+            PolicyUpdatedPayload payload, String eventId, ConsumerRecord<String, String> consumerRecord) {
         // payload가 없으면 종료
         if (payload == null) {
-            log.warn("policy-updated payload is null. recordKey={}", record.key());
+            log.warn("policy-updated payload is null. recordKey={}", consumerRecord.key());
             return false;
         }
 

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -2,6 +2,7 @@ package com.project.domain.policy.infra.messaging;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class PolicyKafkaConsumer {
+    private static final Pattern HHMM_PATTERN = Pattern.compile("^\\d{4}$");
 
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> familyStringRedisTemplate;
@@ -88,6 +90,19 @@ public class PolicyKafkaConsumer {
 
             String newValue = payload.newValue();
             Long targetCustomerId = payload.targetCustomerId();
+            if (newValue != null && !newValue.isBlank()) {
+                if (!isValidPolicyValue(payload.policyKey(), newValue)) {
+                    log.warn(
+                            "Invalid policy value. eventId={}, familyId={}, customerId={},"
+                                    + " field={}, value={}",
+                            eventId,
+                            payload.familyId(),
+                            targetCustomerId,
+                            payload.policyKey(),
+                            newValue);
+                    return;
+                }
+            }
 
             // targetCustomerId != null: 해당하는 customer 정책 적용
             if (targetCustomerId != null) {
@@ -140,5 +155,44 @@ public class PolicyKafkaConsumer {
         }
         // newValue가 있으면 해당 policyKey 필드를 새 값으로 저장 (정책 갱신)
         familyStringRedisTemplate.opsForHash().put(constraintsKey, policyKey, newValue);
+    }
+
+    // value 값 검증
+    private boolean isValidPolicyValue(String policyKey, String newValue) {
+        if (policyKey == null || policyKey.isBlank()) {
+            return false;
+        }
+        if ("THROTTLE:SPEED".equals(policyKey)) {
+            return isPositiveLong(newValue);
+        }
+        if ("BLOCK:ACCESS".equals(policyKey) || policyKey.startsWith("BLOCK:APP:")) {
+            return "1".equals(newValue) || "0".equals(newValue);
+        }
+        if ("BLOCK:TIME:START".equals(policyKey) || "BLOCK:TIME:END".equals(policyKey)) {
+            return isValidHhmm(newValue);
+        }
+        if (policyKey.startsWith("LIMIT:DATA:")) {
+            return isPositiveLong(newValue);
+        }
+
+        // 알 수 없는 정책 키는 v1에서는 허용하지 않음
+        return false;
+    }
+
+    private boolean isPositiveLong(String value) {
+        try {
+            return Long.parseLong(value) > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private boolean isValidHhmm(String value) {
+        if (!HHMM_PATTERN.matcher(value).matches()) {
+            return false;
+        }
+        int hh = Integer.parseInt(value.substring(0, 2));
+        int mm = Integer.parseInt(value.substring(2, 4));
+        return hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59;
     }
 }

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -31,7 +31,7 @@ public class PolicyKafkaConsumer {
     @Value("${app.kafka.dedup.policy-ttl-seconds}")
     private long dedupTtlSeconds;
 
-    @KafkaListener(topics = "policy-updated", groupId = "policy-group")
+    @KafkaListener(topics = "policy-updated", groupId = "dabom-processor-usage-policy-group")
     public void consume(ConsumerRecord<String, String> record) {
         try {
             // 역직렬화

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -174,7 +174,7 @@ public class PolicyKafkaConsumer {
 
     private boolean isDuplicated(String eventId) {
         // dedup 키가 이미 있으면 중복 이벤트로 판단
-        String dedupKey = "event:dedup:policy:" + eventId;
+        String dedupKey = redisKeyGenerator.generatePolicyEventDedupKey(eventId);
         Boolean firstSeen =
                 familyStringRedisTemplate
                         .opsForValue()

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -1,6 +1,7 @@
 package com.project.domain.policy.infra.messaging;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.family.entity.FamilyMember;
+import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.policy.PolicyUpdatedPayload;
 import com.project.global.util.RedisKeyGenerator;
@@ -26,6 +29,7 @@ public class PolicyKafkaConsumer {
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> familyStringRedisTemplate;
     private final RedisKeyGenerator redisKeyGenerator;
+    private final FamilyMemberRepository familyMemberRepository;
 
     // 중복 이벤트 키 TTL 설정 (기본값: 3600초)
     @Value("${app.kafka.dedup.policy-ttl-seconds}")
@@ -70,7 +74,6 @@ public class PolicyKafkaConsumer {
             // payload 필수값 검증
             // 누락시 잘못된 이벤트로 간주하고 종료
             if (payload.familyId() == null
-                    || payload.targetCustomerId() == null
                     || payload.policyKey() == null
                     || payload.policyKey().isBlank()) {
                 log.warn(
@@ -83,32 +86,43 @@ public class PolicyKafkaConsumer {
                 return;
             }
 
-            // constraint 키 생성
-            String constraintsKey =
-                    redisKeyGenerator.generateFamilyCustomerConstraintsKey(
-                            payload.familyId(), payload.targetCustomerId());
-
-            // 정책 반영
-            // newValue가 비어있으면 해당 policyKey 필드를 삭제 (정책 해제)
             String newValue = payload.newValue();
-            if (newValue == null || newValue.isBlank()) {
-                familyStringRedisTemplate.opsForHash().delete(constraintsKey, payload.policyKey());
+            Long targetCustomerId = payload.targetCustomerId();
+
+            // targetCustomerId != null: 해당하는 customer 정책 적용
+            if (targetCustomerId != null) {
+                String constraintsKey =
+                        redisKeyGenerator.generateFamilyCustomerConstraintsKey(
+                                payload.familyId(), targetCustomerId);
+                applyConstraint(constraintsKey, payload.policyKey(), newValue);
                 log.info(
-                        "Removed constraint. eventId={}, key={}, field={}",
+                        "Updated customer constraint. eventId={}, familyId={}, customerId={},"
+                                + " field={}, value={}",
                         eventId,
-                        constraintsKey,
-                        payload.policyKey());
+                        payload.familyId(),
+                        targetCustomerId,
+                        payload.policyKey(),
+                        newValue);
                 return;
             }
 
-            // newValue가 있으면 해당 policyKey 필드를 새 값으로 저장 (정책 갱신)
-            familyStringRedisTemplate
-                    .opsForHash()
-                    .put(constraintsKey, payload.policyKey(), newValue);
+            // targetCustomerId == null: family 전체 정책 -> active customer 전원에게 반영
+            List<FamilyMember> customers =
+                    familyMemberRepository.findAllByFamilyIdAndDeletedAtIsNull(payload.familyId());
+
+            for (FamilyMember customer : customers) {
+                String constraintsKey =
+                        redisKeyGenerator.generateFamilyCustomerConstraintsKey(
+                                payload.familyId(), customer.getCustomerId());
+                applyConstraint(constraintsKey, payload.policyKey(), newValue);
+            }
+
             log.info(
-                    "Updated constraint. eventId={}, key={}, field={}, value={}",
+                    "Updated family-wide constraint. eventId={}, familyId={}, targetCount={},"
+                            + " field={}, value={}",
                     eventId,
-                    constraintsKey,
+                    payload.familyId(),
+                    customers.size(),
                     payload.policyKey(),
                     newValue);
         } catch (JsonProcessingException e) {
@@ -116,5 +130,15 @@ public class PolicyKafkaConsumer {
         } catch (Exception e) {
             log.error("Failed to handle policy-updated event", e);
         }
+    }
+
+    private void applyConstraint(String constraintsKey, String policyKey, String newValue) {
+        // newValue가 비어있으면 해당 policyKey 필드를 삭제 (정책 해제)
+        if (newValue == null || newValue.isBlank()) {
+            familyStringRedisTemplate.opsForHash().delete(constraintsKey, policyKey);
+            return;
+        }
+        // newValue가 있으면 해당 policyKey 필드를 새 값으로 저장 (정책 갱신)
+        familyStringRedisTemplate.opsForHash().put(constraintsKey, policyKey, newValue);
     }
 }

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
@@ -1,10 +1,11 @@
 package com.project.domain.policy.service;
 
-import java.time.Duration;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import com.project.domain.family.entity.FamilyMember;
@@ -23,6 +24,7 @@ public class PolicyConstraintSyncService {
     private static final String VALUE_LOG_SUFFIX = ", value={}";
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
+    private final RedisScript<List> policyConstraintUpdateScript;
     private final RedisKeyGenerator redisKeyGenerator;
     private final FamilyMemberRepository familyMemberRepository;
     private final PolicyEventValidator policyEventValidator;
@@ -39,14 +41,10 @@ public class PolicyConstraintSyncService {
             return;
         }
 
-        // 중복 이벤트는 스킵
-        if (isDuplicated(eventId)) {
-            return;
-        }
-
         String policyKey = payload.policyKey();
         String newValue = payload.newValue();
         Long targetCustomerId = payload.targetCustomerId();
+        long eventVersion = resolveEventVersion(envelope);
 
         // 삭제/갱신 모두 policyKey whitelist 검증
         if (!policyEventValidator.isAllowedPolicyKey(policyKey)) {
@@ -91,63 +89,112 @@ public class PolicyConstraintSyncService {
                 return;
             }
 
-            applyConstraintToCustomer(payload.familyId(), targetCustomerId, policyKey, newValue);
-            log.info(
-                    "Updated customer constraint. eventId={}, familyId={}, customerId={}, field={}"
-                            + VALUE_LOG_SUFFIX,
-                    eventId,
-                    payload.familyId(),
-                    targetCustomerId,
-                    policyKey,
-                    newValue);
+            String result =
+                    applyConstraintToCustomer(
+                            eventId,
+                            eventVersion,
+                            payload.familyId(),
+                            targetCustomerId,
+                            policyKey,
+                            newValue);
+            logResult(eventId, payload.familyId(), targetCustomerId, policyKey, newValue, result);
             return;
         }
 
         // targetCustomerId가 없으면 family 전체(active customer)에게 반영
         List<FamilyMember> customers =
                 familyMemberRepository.findAllByFamilyIdAndDeletedAtIsNull(payload.familyId());
+        int appliedCount = 0;
+        int skippedCount = 0;
         for (FamilyMember customer : customers) {
-            applyConstraintToCustomer(
-                    payload.familyId(), customer.getCustomerId(), policyKey, newValue);
+            String result =
+                    applyConstraintToCustomer(
+                            eventId,
+                            eventVersion,
+                            payload.familyId(),
+                            customer.getCustomerId(),
+                            policyKey,
+                            newValue);
+            if ("APPLIED".equals(result)) {
+                appliedCount++;
+            } else {
+                skippedCount++;
+            }
         }
 
         log.info(
-                "Updated family-wide constraint. eventId={}, familyId={}, targetCount={}, field={}"
+                "Processed family-wide constraint. eventId={}, familyId={}, appliedCount={},"
+                        + " skippedCount={}, field={}"
                         + VALUE_LOG_SUFFIX,
                 eventId,
                 payload.familyId(),
-                customers.size(),
+                appliedCount,
+                skippedCount,
                 policyKey,
                 newValue);
     }
 
-    private boolean isDuplicated(String eventId) {
-        String dedupKey = redisKeyGenerator.generatePolicyEventDedupKey(eventId);
-        Boolean firstSeen =
-                familyStringRedisTemplate
-                        .opsForValue()
-                        .setIfAbsent(dedupKey, "1", Duration.ofSeconds(dedupTtlSeconds));
-
-        if (!Boolean.TRUE.equals(firstSeen)) {
-            log.info("Skip duplicated policy-updated event. eventId={}", eventId);
-            return true;
-        }
-
-        return false;
-    }
-
-    private void applyConstraintToCustomer(
-            Long familyId, Long customerId, String policyKey, String newValue) {
+    private String applyConstraintToCustomer(
+            String eventId,
+            long eventVersion,
+            Long familyId,
+            Long customerId,
+            String policyKey,
+            String newValue) {
+        String dedupKey = redisKeyGenerator.generatePolicyEventDedupKey(eventId, customerId);
         String constraintsKey =
                 redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
-        applyConstraint(constraintsKey, policyKey, newValue);
+        String versionKey =
+                redisKeyGenerator.generateFamilyCustomerConstraintsVersionKey(familyId, customerId);
+        String normalizedNewValue = (newValue == null || newValue.isBlank()) ? "" : newValue;
+
+        List result =
+                familyStringRedisTemplate.execute(
+                        policyConstraintUpdateScript,
+                        List.of(dedupKey, constraintsKey, versionKey),
+                        String.valueOf(dedupTtlSeconds),
+                        policyKey,
+                        normalizedNewValue,
+                        String.valueOf(eventVersion));
+        if (result.isEmpty()) {
+            return "UNKNOWN";
+        }
+        return String.valueOf(result.getFirst());
     }
 
-    private void applyConstraint(String constraintsKey, String policyKey, String newValue) {
-        if (newValue == null || newValue.isBlank()) {
-            familyStringRedisTemplate.opsForHash().delete(constraintsKey, policyKey);
+    private long resolveEventVersion(EventEnvelope<PolicyUpdatedPayload> envelope) {
+        if (envelope.timestamp() == null) {
+            return System.currentTimeMillis();
+        }
+        return envelope.timestamp().toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    private void logResult(
+            String eventId,
+            Long familyId,
+            Long customerId,
+            String policyKey,
+            String newValue,
+            String result) {
+        if ("APPLIED".equals(result)) {
+            log.info(
+                    "Updated customer constraint. eventId={}, familyId={}, customerId={}, field={}"
+                            + VALUE_LOG_SUFFIX,
+                    eventId,
+                    familyId,
+                    customerId,
+                    policyKey,
+                    newValue);
             return;
         }
-        familyStringRedisTemplate.opsForHash().put(constraintsKey, policyKey, newValue);
+
+        log.info(
+                "Skipped customer constraint update. eventId={}, familyId={}, customerId={},"
+                        + " field={}, reason={}",
+                eventId,
+                familyId,
+                customerId,
+                policyKey,
+                result);
     }
 }

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
@@ -24,7 +24,7 @@ public class PolicyConstraintSyncService {
     private static final String VALUE_LOG_SUFFIX = ", value={}";
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
-    private final RedisScript<List> policyConstraintUpdateScript;
+    private final RedisScript<List<String>> policyConstraintUpdateScript;
     private final RedisKeyGenerator redisKeyGenerator;
     private final FamilyMemberRepository familyMemberRepository;
     private final PolicyEventValidator policyEventValidator;
@@ -148,7 +148,7 @@ public class PolicyConstraintSyncService {
                 redisKeyGenerator.generateFamilyCustomerConstraintsVersionKey(familyId, customerId);
         String normalizedNewValue = (newValue == null || newValue.isBlank()) ? "" : newValue;
 
-        List result =
+        List<String> result =
                 familyStringRedisTemplate.execute(
                         policyConstraintUpdateScript,
                         List.of(dedupKey, constraintsKey, versionKey),
@@ -156,10 +156,10 @@ public class PolicyConstraintSyncService {
                         policyKey,
                         normalizedNewValue,
                         String.valueOf(eventVersion));
-        if (result.isEmpty()) {
+        if (result == null || result.isEmpty()) {
             return "UNKNOWN";
         }
-        return String.valueOf(result.getFirst());
+        return String.valueOf(result.get(0));
     }
 
     private long resolveEventVersion(EventEnvelope<PolicyUpdatedPayload> envelope) {

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
@@ -1,0 +1,152 @@
+package com.project.domain.policy.service;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.project.domain.family.entity.FamilyMember;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.policy.PolicyUpdatedPayload;
+import com.project.global.util.RedisKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PolicyConstraintSyncService {
+
+    private final RedisTemplate<String, String> familyStringRedisTemplate;
+    private final RedisKeyGenerator redisKeyGenerator;
+    private final FamilyMemberRepository familyMemberRepository;
+    private final PolicyEventValidator policyEventValidator;
+
+    @Value("${app.kafka.dedup.policy-ttl-seconds}")
+    private long dedupTtlSeconds;
+
+    public void sync(EventEnvelope<PolicyUpdatedPayload> envelope, String recordKey) {
+        PolicyUpdatedPayload payload = envelope.payload();
+        String eventId = envelope.eventId();
+
+        // payload/eventId/필수값 검증
+        if (!policyEventValidator.isValidPayload(payload, eventId, recordKey)) {
+            return;
+        }
+
+        // 중복 이벤트는 스킵
+        if (isDuplicated(eventId)) {
+            return;
+        }
+
+        String policyKey = payload.policyKey();
+        String newValue = payload.newValue();
+        Long targetCustomerId = payload.targetCustomerId();
+
+        // 삭제/갱신 모두 policyKey whitelist 검증
+        if (!policyEventValidator.isAllowedPolicyKey(policyKey)) {
+            log.warn(
+                    "Invalid policy key. eventId={}, familyId={}, customerId={}, field={}",
+                    eventId,
+                    payload.familyId(),
+                    targetCustomerId,
+                    policyKey);
+            return;
+        }
+
+        // 갱신일 때만 값 형식 검증
+        if (newValue != null
+                && !newValue.isBlank()
+                && !policyEventValidator.isValidPolicyValue(policyKey, newValue)) {
+            log.warn(
+                    "Invalid policy value. eventId={}, familyId={}, customerId={}, field={},"
+                            + " value={}",
+                    eventId,
+                    payload.familyId(),
+                    targetCustomerId,
+                    policyKey,
+                    newValue);
+            return;
+        }
+
+        // targetCustomerId가 있으면 해당 customer만 반영
+        if (targetCustomerId != null) {
+            // family-customer 소속 관계 검증
+            boolean isFamilyMember =
+                    familyMemberRepository.existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(
+                            payload.familyId(), targetCustomerId);
+            if (!isFamilyMember) {
+                log.warn(
+                        "Skip policy update due to invalid family-customer relation."
+                                + " eventId={}, familyId={}, customerId={}, field={}",
+                        eventId,
+                        payload.familyId(),
+                        targetCustomerId,
+                        policyKey);
+                return;
+            }
+
+            applyConstraintToCustomer(payload.familyId(), targetCustomerId, policyKey, newValue);
+            log.info(
+                    "Updated customer constraint. eventId={}, familyId={}, customerId={}, field={},"
+                            + " value={}",
+                    eventId,
+                    payload.familyId(),
+                    targetCustomerId,
+                    policyKey,
+                    newValue);
+            return;
+        }
+
+        // targetCustomerId가 없으면 family 전체(active customer)에게 반영
+        List<FamilyMember> customers =
+                familyMemberRepository.findAllByFamilyIdAndDeletedAtIsNull(payload.familyId());
+        for (FamilyMember customer : customers) {
+            applyConstraintToCustomer(
+                    payload.familyId(), customer.getCustomerId(), policyKey, newValue);
+        }
+
+        log.info(
+                "Updated family-wide constraint. eventId={}, familyId={}, targetCount={}, field={},"
+                        + " value={}",
+                eventId,
+                payload.familyId(),
+                customers.size(),
+                policyKey,
+                newValue);
+    }
+
+    private boolean isDuplicated(String eventId) {
+        String dedupKey = redisKeyGenerator.generatePolicyEventDedupKey(eventId);
+        Boolean firstSeen =
+                familyStringRedisTemplate
+                        .opsForValue()
+                        .setIfAbsent(dedupKey, "1", Duration.ofSeconds(dedupTtlSeconds));
+
+        if (!Boolean.TRUE.equals(firstSeen)) {
+            log.info("Skip duplicated policy-updated event. eventId={}", eventId);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void applyConstraintToCustomer(
+            Long familyId, Long customerId, String policyKey, String newValue) {
+        String constraintsKey =
+                redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
+        applyConstraint(constraintsKey, policyKey, newValue);
+    }
+
+    private void applyConstraint(String constraintsKey, String policyKey, String newValue) {
+        if (newValue == null || newValue.isBlank()) {
+            familyStringRedisTemplate.opsForHash().delete(constraintsKey, policyKey);
+            return;
+        }
+        familyStringRedisTemplate.opsForHash().put(constraintsKey, policyKey, newValue);
+    }
+}

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class PolicyConstraintSyncService {
+    private static final String VALUE_LOG_SUFFIX = ", value={}";
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
     private final RedisKeyGenerator redisKeyGenerator;
@@ -63,8 +64,8 @@ public class PolicyConstraintSyncService {
                 && !newValue.isBlank()
                 && !policyEventValidator.isValidPolicyValue(policyKey, newValue)) {
             log.warn(
-                    "Invalid policy value. eventId={}, familyId={}, customerId={}, field={},"
-                            + " value={}",
+                    "Invalid policy value. eventId={}, familyId={}, customerId={}, field={}"
+                            + VALUE_LOG_SUFFIX,
                     eventId,
                     payload.familyId(),
                     targetCustomerId,
@@ -92,8 +93,8 @@ public class PolicyConstraintSyncService {
 
             applyConstraintToCustomer(payload.familyId(), targetCustomerId, policyKey, newValue);
             log.info(
-                    "Updated customer constraint. eventId={}, familyId={}, customerId={}, field={},"
-                            + " value={}",
+                    "Updated customer constraint. eventId={}, familyId={}, customerId={}, field={}"
+                            + VALUE_LOG_SUFFIX,
                     eventId,
                     payload.familyId(),
                     targetCustomerId,
@@ -111,8 +112,8 @@ public class PolicyConstraintSyncService {
         }
 
         log.info(
-                "Updated family-wide constraint. eventId={}, familyId={}, targetCount={}, field={},"
-                        + " value={}",
+                "Updated family-wide constraint. eventId={}, familyId={}, targetCount={}, field={}"
+                        + VALUE_LOG_SUFFIX,
                 eventId,
                 payload.familyId(),
                 customers.size(),

--- a/src/main/java/com/project/domain/policy/service/PolicyEventValidator.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyEventValidator.java
@@ -1,0 +1,114 @@
+package com.project.domain.policy.service;
+
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import com.project.global.event.dto.policy.PolicyUpdatedPayload;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class PolicyEventValidator {
+    private static final Pattern HHMM_PATTERN = Pattern.compile("^\\d{4}$");
+    private static final Predicate<String> BINARY_FLAG_VALIDATOR =
+            value -> "1".equals(value) || "0".equals(value);
+    private static final Predicate<String> POSITIVE_LONG_VALIDATOR =
+            PolicyEventValidator::isPositiveLongValue;
+    private static final Predicate<String> HHMM_VALIDATOR = PolicyEventValidator::isValidHhmmValue;
+
+    private static final Map<String, Predicate<String>> EXACT_VALUE_VALIDATORS =
+            Map.of(
+                    "THROTTLE:SPEED", POSITIVE_LONG_VALIDATOR,
+                    "BLOCK:ACCESS", BINARY_FLAG_VALIDATOR,
+                    "BLOCK:TIME:START", HHMM_VALIDATOR,
+                    "BLOCK:TIME:END", HHMM_VALIDATOR);
+
+    private static final Map<String, Predicate<String>> PREFIX_VALUE_VALIDATORS =
+            Map.of("BLOCK:APP:", BINARY_FLAG_VALIDATOR, "LIMIT:DATA:", POSITIVE_LONG_VALIDATOR);
+
+    public boolean isValidPayload(PolicyUpdatedPayload payload, String eventId, String recordKey) {
+        if (payload == null) {
+            log.warn("policy-updated payload is null. recordKey={}", recordKey);
+            return false;
+        }
+
+        if (eventId == null || eventId.isBlank()) {
+            log.warn(
+                    "policy-updated eventId is empty. familyId={}, customerId={}, policyKey={}",
+                    payload.familyId(),
+                    payload.targetCustomerId(),
+                    payload.policyKey());
+            return false;
+        }
+
+        if (payload.familyId() == null
+                || payload.policyKey() == null
+                || payload.policyKey().isBlank()) {
+            log.warn(
+                    "Invalid policy-updated payload. eventId={}, familyId={}, customerId={},"
+                            + " policyKey={}",
+                    eventId,
+                    payload.familyId(),
+                    payload.targetCustomerId(),
+                    payload.policyKey());
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean isAllowedPolicyKey(String policyKey) {
+        if (policyKey == null || policyKey.isBlank()) {
+            return false;
+        }
+        if (EXACT_VALUE_VALIDATORS.containsKey(policyKey)) {
+            return true;
+        }
+        return findPrefixValidator(policyKey) != null;
+    }
+
+    public boolean isValidPolicyValue(String policyKey, String newValue) {
+        if (policyKey == null || policyKey.isBlank()) {
+            return false;
+        }
+        Predicate<String> exactValidator = EXACT_VALUE_VALIDATORS.get(policyKey);
+        if (exactValidator != null) {
+            return exactValidator.test(newValue);
+        }
+        Predicate<String> prefixValidator = findPrefixValidator(policyKey);
+        if (prefixValidator != null) {
+            return prefixValidator.test(newValue);
+        }
+        return false;
+    }
+
+    private Predicate<String> findPrefixValidator(String policyKey) {
+        for (Map.Entry<String, Predicate<String>> entry : PREFIX_VALUE_VALIDATORS.entrySet()) {
+            if (policyKey.startsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static boolean isPositiveLongValue(String value) {
+        try {
+            return Long.parseLong(value) > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static boolean isValidHhmmValue(String value) {
+        if (!HHMM_PATTERN.matcher(value).matches()) {
+            return false;
+        }
+        int hh = Integer.parseInt(value.substring(0, 2));
+        int mm = Integer.parseInt(value.substring(2, 4));
+        return hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59;
+    }
+}

--- a/src/main/java/com/project/global/config/RedisConfig.java
+++ b/src/main/java/com/project/global/config/RedisConfig.java
@@ -81,10 +81,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public DefaultRedisScript<List> policyConstraintUpdateScript() {
-        DefaultRedisScript<List> script = new DefaultRedisScript<>();
+    @SuppressWarnings("unchecked")
+    public DefaultRedisScript<List<String>> policyConstraintUpdateScript() {
+        DefaultRedisScript<List<String>> script = new DefaultRedisScript<>();
         script.setLocation(new ClassPathResource("lua/policy_constraint_update.lua"));
-        script.setResultType(List.class);
+        script.setResultType((Class<List<String>>) (Class<?>) List.class);
         return script;
     }
 }

--- a/src/main/java/com/project/global/config/RedisConfig.java
+++ b/src/main/java/com/project/global/config/RedisConfig.java
@@ -1,9 +1,13 @@
 package com.project.global.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -74,5 +78,13 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public DefaultRedisScript<List> policyConstraintUpdateScript() {
+        DefaultRedisScript<List> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/policy_constraint_update.lua"));
+        script.setResultType(List.class);
+        return script;
     }
 }

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -35,6 +35,18 @@ public class RedisKeyGenerator {
                 + "monthly";
     }
 
+    public String generateFamilyCustomerConstraintsKey(Long familyId, Long customerId) {
+        return FAMILY_KEY_PREFIX
+                + KEY_SEPARATOR
+                + familyId
+                + KEY_SEPARATOR
+                + "customer"
+                + KEY_SEPARATOR
+                + customerId
+                + KEY_SEPARATOR
+                + "constraints";
+    }
+
     public String generateFamilyKey(Long familyId) {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId;
     }

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -8,6 +8,7 @@ public class RedisKeyGenerator {
     private static final String KEY_SEPARATOR = ":";
     private static final String EXAMPLE_KEY_PREFIX = "example";
     private static final String FAMILY_KEY_PREFIX = "family";
+    private static final String POLICY_EVENT_DEDUP_KEY_PREFIX = "event:dedup:policy";
 
     public String generateExampleKey(Long exampleId) {
         return EXAMPLE_KEY_PREFIX + KEY_SEPARATOR + exampleId;
@@ -49,5 +50,9 @@ public class RedisKeyGenerator {
 
     public String generateFamilyKey(Long familyId) {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId;
+    }
+
+    public String generatePolicyEventDedupKey(String eventId) {
+        return POLICY_EVENT_DEDUP_KEY_PREFIX + KEY_SEPARATOR + eventId;
     }
 }

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -48,11 +48,13 @@ public class RedisKeyGenerator {
                 + "constraints";
     }
 
-    public String generateFamilyKey(Long familyId) {
-        return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId;
+    public String generateFamilyCustomerConstraintsVersionKey(Long familyId, Long customerId) {
+        return generateFamilyCustomerConstraintsKey(familyId, customerId)
+                + KEY_SEPARATOR
+                + "version";
     }
 
-    public String generatePolicyEventDedupKey(String eventId) {
-        return POLICY_EVENT_DEDUP_KEY_PREFIX + KEY_SEPARATOR + eventId;
+    public String generatePolicyEventDedupKey(String eventId, Long customerId) {
+        return POLICY_EVENT_DEDUP_KEY_PREFIX + KEY_SEPARATOR + eventId + KEY_SEPARATOR + customerId;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,3 +80,8 @@ logging:
     root: INFO
     org.springframework.web: INFO
     org.hibernate.SQL: WARN
+
+app:
+  kafka:
+    dedup:
+      policy-ttl-seconds: ${POLICY_DEDUP_TTL_SECONDS:3600}

--- a/src/main/resources/lua/policy_constraint_update.lua
+++ b/src/main/resources/lua/policy_constraint_update.lua
@@ -1,0 +1,62 @@
+-- policy_constraint_update.lua
+--
+-- Purpose:
+--   Atomically apply one customer constraint update with dedup + stale-event guard.
+--
+-- KEYS
+--   KEYS[1]: event:dedup:policy:{eventId}:{customerId}
+--   KEYS[2]: family:{familyId}:customer:{customerId}:constraints
+--   KEYS[3]: family:{familyId}:customer:{customerId}:constraints:version
+--
+-- ARGV
+--   ARGV[1]: dedup_ttl_seconds
+--   ARGV[2]: policy_key
+--   ARGV[3]: new_value (blank => delete)
+--   ARGV[4]: event_timestamp_epoch_millis
+--
+-- Return (array)
+--   {"APPLIED", "HSET"|"HDEL"}
+--   {"DUPLICATE"}
+--   {"STALE", last_applied_version}
+--   {"INVALID_REQUEST", reason}
+
+local dedup_key = KEYS[1]
+local constraints_key = KEYS[2]
+local version_key = KEYS[3]
+
+local dedup_ttl = tonumber(ARGV[1])
+local policy_key = ARGV[2]
+local new_value = ARGV[3]
+local event_version = tonumber(ARGV[4])
+
+if not dedup_ttl or dedup_ttl <= 0 then
+    return {"INVALID_REQUEST", "INVALID_DEDUP_TTL"}
+end
+
+if not policy_key or policy_key == "" then
+    return {"INVALID_REQUEST", "EMPTY_POLICY_KEY"}
+end
+
+if not event_version then
+    return {"INVALID_REQUEST", "INVALID_EVENT_VERSION"}
+end
+
+local first_seen = redis.call("SET", dedup_key, "1", "NX", "EX", dedup_ttl)
+if not first_seen then
+    return {"DUPLICATE"}
+end
+
+local last_applied = tonumber(redis.call("HGET", version_key, policy_key) or "-1")
+if event_version < last_applied then
+    return {"STALE", tostring(last_applied)}
+end
+
+if not new_value or new_value == "" then
+    redis.call("HDEL", constraints_key, policy_key)
+    redis.call("HSET", version_key, policy_key, tostring(event_version))
+    return {"APPLIED", "HDEL"}
+end
+
+redis.call("HSET", constraints_key, policy_key, new_value)
+redis.call("HSET", version_key, policy_key, tostring(event_version))
+return {"APPLIED", "HSET"}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #4 
- jira: DABOM-146

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
`processor-usage`에서 `policy-updated` 이벤트를 소비해 Redis constraints를 즉시 갱신한다.
스케일 아웃 환경에서 동시 반영 충돌/중복/역순 이벤트 문제를 줄이기 위해 Lua 원자 연산 기반으로 처리한다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `policy-updated` Kafka 컨슈머 추가
- `EventEnvelope<PolicyUpdatedPayload>` 파싱 및 유효성 검증 처리
- Redis Lua 스크립트 적용: `policy_constraint_update.lua`
- Redis dedup 키 변경: `event:dedup:policy:{eventId}:{customerId}`
- dedup TTL 설정 외부화: `app.kafka.dedup.policy-ttl-seconds` (기본 3600초)
- constraints 키 생성 메서드 추가:
  - `family:{familyId}:customer:{customerId}:constraints`
- constraints version 키 생성 메서드 추가:
  - `family:{familyId}:customer:{customerId}:constraints:version`
- family 전체 정책 반영 추가:
  - `targetCustomerId == null`이면 `family_member`의 활성 구성원 전원에게 동일 정책 반영
- 정책 반영 규칙 구현:
  - `newValue` 존재 시 `HSET`
  - `newValue` 공백/NULL 시 `HDEL`
  - 반영 시 policyKey별 version 갱신(`epochMillis`)
  - 더 오래된 이벤트(`eventVersion < lastAppliedVersion`)는 `STALE`로 스킵
- 정책 값 형식 검증 추가:
  - `LIMIT:DATA:*`, `THROTTLE:SPEED`: 양의 정수
  - `BLOCK:ACCESS`, `BLOCK:APP:*`: `0` 또는 `1`
  - `BLOCK:TIME:START/END`: `HHMM` 형식 + 시/분 범위 검증

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|        |            |         |            |        |       |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// 코드는 이 사이에 작성하면 됩니다.
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 현재는 알 수 없는 `policyKey`는 reject하고 skip 로그만 남긴다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
- 테스트 예시
  - Lua 단독: `EVAL`로 `APPLIED / DUPLICATE / STALE / HDEL` 검증
  - Redis: `HGET family:1:customer:3:constraints LIMIT:DATA:MONTHLY`
  - Redis: `HGET family:1:customer:3:constraints:version LIMIT:DATA:MONTHLY`
  - Kafka: `policy-updated` 토픽에 동일 `eventId` 재발행 시 customer 단위 dedup 동작 확인