### PR TITLE
[DABOM-147] usage-persist 컨슈머 구현

### DIFF
--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import com.project.global.util.BaseEntity;
 
@@ -17,7 +18,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "customer_quota")
+@Table(
+        name = "customer_quota",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_customer_quota_family_customer_month",
+                    columnNames = {"family_id", "customer_id", "current_month"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CustomerQuota extends BaseEntity {

--- a/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
+++ b/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
@@ -1,6 +1,7 @@
 package com.project.domain.customer.repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,6 +11,9 @@ import org.springframework.data.repository.query.Param;
 import com.project.domain.customer.entity.CustomerQuota;
 
 public interface CustomerQuotaRepository extends JpaRepository<CustomerQuota, Long> {
+
+    Optional<CustomerQuota> findTopByFamilyIdAndCustomerIdAndDeletedAtIsNullOrderByCurrentMonthDesc(
+            Long familyId, Long customerId);
 
     @Modifying
     @Query(

--- a/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
+++ b/src/main/java/com/project/domain/customer/repository/CustomerQuotaRepository.java
@@ -1,0 +1,27 @@
+package com.project.domain.customer.repository;
+
+import java.time.LocalDate;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.project.domain.customer.entity.CustomerQuota;
+
+public interface CustomerQuotaRepository extends JpaRepository<CustomerQuota, Long> {
+
+    @Modifying
+    @Query(
+            "update CustomerQuota c "
+                    + "set c.monthlyUsedBytes = c.monthlyUsedBytes + :bytesUsed "
+                    + "where c.familyId = :familyId "
+                    + "and c.customerId = :customerId "
+                    + "and c.currentMonth = :currentMonth "
+                    + "and c.deletedAt is null")
+    int incrementMonthlyUsedBytes(
+            @Param("familyId") Long familyId,
+            @Param("customerId") Long customerId,
+            @Param("currentMonth") LocalDate currentMonth,
+            @Param("bytesUsed") Long bytesUsed);
+}

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.policy.service.PolicyConstraintSyncService;
+import com.project.global.event.KafkaEventMessageSupport;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.policy.PolicyUpdatedPayload;
 
@@ -19,44 +19,31 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class PolicyKafkaConsumer {
-    private static final String EVENT_TYPE_FIELD = "eventType";
     private static final String POLICY_UPDATED_EVENT_TYPE = "POLICY_UPDATED";
-    private static final int MAX_LOG_VALUE_LENGTH = 128;
 
-    private final ObjectMapper objectMapper;
+    private final KafkaEventMessageSupport kafkaEventMessageSupport;
     private final PolicyConstraintSyncService policyConstraintSyncService;
 
     @KafkaListener(topics = "policy-updated", groupId = "dabom-processor-usage-policy-group")
     public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
-            JsonNode root = objectMapper.readTree(consumerRecord.value());
-            String eventType = root.path(EVENT_TYPE_FIELD).asText("");
+            JsonNode root = kafkaEventMessageSupport.readTree(consumerRecord.value());
+            String eventType = kafkaEventMessageSupport.extractEventType(root);
             if (!POLICY_UPDATED_EVENT_TYPE.equals(eventType)) {
                 log.warn(
                         "Skip non-policy event on policy-updated topic. recordKey={}, eventType={}",
                         consumerRecord.key(),
-                        sanitizeForLog(eventType));
+                        kafkaEventMessageSupport.sanitizeForLog(eventType));
                 return;
             }
 
             EventEnvelope<PolicyUpdatedPayload> envelope =
-                    objectMapper.convertValue(root, new TypeReference<>() {});
+                    kafkaEventMessageSupport.convertToEnvelope(root, new TypeReference<>() {});
             policyConstraintSyncService.sync(envelope, consumerRecord.key());
         } catch (JsonProcessingException e) {
             log.error("Failed to parse policy-updated payload", e);
         } catch (Exception e) {
             log.error("Failed to handle policy-updated event", e);
         }
-    }
-
-    private String sanitizeForLog(String raw) {
-        if (raw == null) {
-            return "null";
-        }
-        String sanitized = raw.replace('\r', '_').replace('\n', '_').replace('\t', '_');
-        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
-            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
-        }
-        return sanitized;
     }
 }

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PolicyKafkaConsumer {
     private static final String EVENT_TYPE_FIELD = "eventType";
     private static final String POLICY_UPDATED_EVENT_TYPE = "POLICY_UPDATED";
+    private static final int MAX_LOG_VALUE_LENGTH = 128;
 
     private final ObjectMapper objectMapper;
     private final PolicyConstraintSyncService policyConstraintSyncService;
@@ -34,17 +35,28 @@ public class PolicyKafkaConsumer {
                 log.warn(
                         "Skip non-policy event on policy-updated topic. recordKey={}, eventType={}",
                         consumerRecord.key(),
-                        eventType);
+                        sanitizeForLog(eventType));
                 return;
             }
 
             EventEnvelope<PolicyUpdatedPayload> envelope =
-                    objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
+                    objectMapper.convertValue(root, new TypeReference<>() {});
             policyConstraintSyncService.sync(envelope, consumerRecord.key());
         } catch (JsonProcessingException e) {
             log.error("Failed to parse policy-updated payload", e);
         } catch (Exception e) {
             log.error("Failed to handle policy-updated event", e);
         }
+    }
+
+    private String sanitizeForLog(String raw) {
+        if (raw == null) {
+            return "null";
+        }
+        String sanitized = raw.replace('\r', '_').replace('\n', '_').replace('\t', '_');
+        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
+            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
+        }
+        return sanitized;
     }
 }

--- a/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
+++ b/src/main/java/com/project/domain/policy/infra/messaging/PolicyKafkaConsumer.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.policy.service.PolicyConstraintSyncService;
 import com.project.global.event.dto.EventEnvelope;
@@ -18,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class PolicyKafkaConsumer {
+    private static final String EVENT_TYPE_FIELD = "eventType";
+    private static final String POLICY_UPDATED_EVENT_TYPE = "POLICY_UPDATED";
 
     private final ObjectMapper objectMapper;
     private final PolicyConstraintSyncService policyConstraintSyncService;
@@ -25,6 +28,16 @@ public class PolicyKafkaConsumer {
     @KafkaListener(topics = "policy-updated", groupId = "dabom-processor-usage-policy-group")
     public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
+            JsonNode root = objectMapper.readTree(consumerRecord.value());
+            String eventType = root.path(EVENT_TYPE_FIELD).asText("");
+            if (!POLICY_UPDATED_EVENT_TYPE.equals(eventType)) {
+                log.warn(
+                        "Skip non-policy event on policy-updated topic. recordKey={}, eventType={}",
+                        consumerRecord.key(),
+                        eventType);
+                return;
+            }
+
             EventEnvelope<PolicyUpdatedPayload> envelope =
                     objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
             policyConstraintSyncService.sync(envelope, consumerRecord.key());

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
@@ -27,6 +27,7 @@ public class UsagePersistKafkaConsumer {
     @KafkaListener(topics = "usage-persist", groupId = "dabom-processor-usage-persistence-group")
     public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
+            // 메시지에서 eventType 확인 후 정상 메시지만 변환
             JsonNode root = kafkaEventMessageSupport.readTree(consumerRecord.value());
             String eventType = kafkaEventMessageSupport.extractEventType(root);
             if (!USAGE_PERSIST_EVENT_TYPE.equals(eventType)) {

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.usage.service.UsagePersistService;
 import com.project.global.event.dto.EventEnvelope;
@@ -18,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class UsagePersistKafkaConsumer {
+    private static final String EVENT_TYPE_FIELD = "eventType";
+    private static final String USAGE_PERSIST_EVENT_TYPE = "USAGE_PERSIST";
 
     private final ObjectMapper objectMapper;
     private final UsagePersistService usagePersistService;
@@ -25,6 +28,16 @@ public class UsagePersistKafkaConsumer {
     @KafkaListener(topics = "usage-persist", groupId = "dabom-processor-usage-persistence-group")
     public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
+            JsonNode root = objectMapper.readTree(consumerRecord.value());
+            String eventType = root.path(EVENT_TYPE_FIELD).asText("");
+            if (!USAGE_PERSIST_EVENT_TYPE.equals(eventType)) {
+                log.warn(
+                        "Skip non-persist event on usage-persist topic. recordKey={}, eventType={}",
+                        consumerRecord.key(),
+                        eventType);
+                return;
+            }
+
             EventEnvelope<UsagePersistPayload> envelope =
                     objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
             usagePersistService.persist(envelope, consumerRecord.key());

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
@@ -1,0 +1,38 @@
+package com.project.domain.usage.infra.messaging;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.usage.service.UsagePersistService;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsagePersistPayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsagePersistKafkaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final UsagePersistService usagePersistService;
+
+    @KafkaListener(topics = "usage-persist", groupId = "dabom-processor-usage-persistence-group")
+    public void consume(ConsumerRecord<String, String> consumerRecord) {
+        try {
+            EventEnvelope<UsagePersistPayload> envelope =
+                    objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
+            usagePersistService.persist(envelope, consumerRecord.key());
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse usage-persist payload", e);
+        } catch (Exception e) {
+            log.error("Failed to handle usage-persist event", e);
+        }
+    }
+}

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UsagePersistKafkaConsumer {
     private static final String EVENT_TYPE_FIELD = "eventType";
     private static final String USAGE_PERSIST_EVENT_TYPE = "USAGE_PERSIST";
+    private static final int MAX_LOG_VALUE_LENGTH = 128;
 
     private final ObjectMapper objectMapper;
     private final UsagePersistService usagePersistService;
@@ -34,12 +35,12 @@ public class UsagePersistKafkaConsumer {
                 log.warn(
                         "Skip non-persist event on usage-persist topic. recordKey={}, eventType={}",
                         consumerRecord.key(),
-                        eventType);
+                        sanitizeForLog(eventType));
                 return;
             }
 
             EventEnvelope<UsagePersistPayload> envelope =
-                    objectMapper.readValue(consumerRecord.value(), new TypeReference<>() {});
+                    objectMapper.convertValue(root, new TypeReference<>() {});
             usagePersistService.persist(envelope, consumerRecord.key());
 
         } catch (JsonProcessingException e) {
@@ -47,5 +48,16 @@ public class UsagePersistKafkaConsumer {
         } catch (Exception e) {
             log.error("Failed to handle usage-persist event", e);
         }
+    }
+
+    private String sanitizeForLog(String raw) {
+        if (raw == null) {
+            return "null";
+        }
+        String sanitized = raw.replace('\r', '_').replace('\n', '_').replace('\t', '_');
+        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
+            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
+        }
+        return sanitized;
     }
 }

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsagePersistKafkaConsumer.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.usage.service.UsagePersistService;
+import com.project.global.event.KafkaEventMessageSupport;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.usage.UsagePersistPayload;
 
@@ -19,28 +19,26 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class UsagePersistKafkaConsumer {
-    private static final String EVENT_TYPE_FIELD = "eventType";
     private static final String USAGE_PERSIST_EVENT_TYPE = "USAGE_PERSIST";
-    private static final int MAX_LOG_VALUE_LENGTH = 128;
 
-    private final ObjectMapper objectMapper;
+    private final KafkaEventMessageSupport kafkaEventMessageSupport;
     private final UsagePersistService usagePersistService;
 
     @KafkaListener(topics = "usage-persist", groupId = "dabom-processor-usage-persistence-group")
     public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
-            JsonNode root = objectMapper.readTree(consumerRecord.value());
-            String eventType = root.path(EVENT_TYPE_FIELD).asText("");
+            JsonNode root = kafkaEventMessageSupport.readTree(consumerRecord.value());
+            String eventType = kafkaEventMessageSupport.extractEventType(root);
             if (!USAGE_PERSIST_EVENT_TYPE.equals(eventType)) {
                 log.warn(
                         "Skip non-persist event on usage-persist topic. recordKey={}, eventType={}",
                         consumerRecord.key(),
-                        sanitizeForLog(eventType));
+                        kafkaEventMessageSupport.sanitizeForLog(eventType));
                 return;
             }
 
             EventEnvelope<UsagePersistPayload> envelope =
-                    objectMapper.convertValue(root, new TypeReference<>() {});
+                    kafkaEventMessageSupport.convertToEnvelope(root, new TypeReference<>() {});
             usagePersistService.persist(envelope, consumerRecord.key());
 
         } catch (JsonProcessingException e) {
@@ -48,16 +46,5 @@ public class UsagePersistKafkaConsumer {
         } catch (Exception e) {
             log.error("Failed to handle usage-persist event", e);
         }
-    }
-
-    private String sanitizeForLog(String raw) {
-        if (raw == null) {
-            return "null";
-        }
-        String sanitized = raw.replace('\r', '_').replace('\n', '_').replace('\t', '_');
-        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
-            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
-        }
-        return sanitized;
     }
 }

--- a/src/main/java/com/project/domain/usage/service/UsagePersistEventValidator.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistEventValidator.java
@@ -1,0 +1,51 @@
+package com.project.domain.usage.service;
+
+import org.springframework.stereotype.Component;
+
+import com.project.global.event.dto.usage.UsagePersistPayload;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class UsagePersistEventValidator {
+
+    public boolean isValidPayload(UsagePersistPayload payload, String eventId, String recordKey) {
+        if (payload == null) {
+            log.warn("usage-persist payload is null. recordKey={}", recordKey);
+            return false;
+        }
+
+        if (payload.originEventId() == null || payload.originEventId().isBlank()) {
+            log.warn(
+                    "usage-persist originEventId is empty. eventId={}, familyId={}, customerId={}",
+                    eventId,
+                    payload.familyId(),
+                    payload.customerId());
+            return false;
+        }
+
+        if (payload.familyId() == null || payload.customerId() == null) {
+            log.warn(
+                    "usage-persist family/customer is invalid. eventId={}, originEventId={},"
+                            + " familyId={}, customerId={}",
+                    eventId,
+                    payload.originEventId(),
+                    payload.familyId(),
+                    payload.customerId());
+            return false;
+        }
+
+        if (payload.bytesUsed() == null || payload.bytesUsed() <= 0) {
+            log.warn(
+                    "usage-persist bytesUsed is invalid. eventId={}, originEventId={},"
+                            + " bytesUsed={}",
+                    eventId,
+                    payload.originEventId(),
+                    payload.bytesUsed());
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/project/domain/usage/service/UsagePersistService.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistService.java
@@ -137,8 +137,7 @@ public class UsagePersistService {
                                     Duration.ofSeconds(usagePersistDedupTtlSeconds));
             if (!Boolean.TRUE.equals(firstSeen)) {
                 log.info(
-                        "Skip duplicated usage-persist event. originEventId={}",
-                        safeOriginEventId);
+                        "Skip duplicated usage-persist event. originEventId={}", safeOriginEventId);
                 return true;
             }
             return false;
@@ -159,9 +158,9 @@ public class UsagePersistService {
         try {
             LocalDate parsedMonth =
                     OffsetDateTime.parse(eventTime)
-                    .atZoneSameInstant(KST)
-                    .toLocalDate()
-                    .withDayOfMonth(1);
+                            .atZoneSameInstant(KST)
+                            .toLocalDate()
+                            .withDayOfMonth(1);
             if (isOutsideAllowedMonthWindow(parsedMonth, currentMonth)) {
                 log.warn(
                         "Suspicious eventTime month. Fallback to current month. eventTime={},"

--- a/src/main/java/com/project/domain/usage/service/UsagePersistService.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistService.java
@@ -53,15 +53,20 @@ public class UsagePersistService {
         String safeEventId = sanitizeForLog(eventId);
         String safeOriginEventId = sanitizeForLog(payload == null ? null : payload.originEventId());
 
+        // payload 검증
         if (!usagePersistEventValidator.isValidPayload(payload, eventId, recordKey)) {
             return;
         }
 
+        // 중복 이벤트 차단
         if (isDuplicated(payload.originEventId(), safeOriginEventId)) {
             return;
         }
 
+        // eventType으로 KST 월(yyyy-MM-01) 계산
         LocalDate currentMonth = resolveCurrentMonth(payload.eventTime());
+
+        // DB update 먼저 수행
         int updatedRows =
                 customerQuotaRepository.incrementMonthlyUsedBytes(
                         payload.familyId(),
@@ -81,6 +86,7 @@ public class UsagePersistService {
             return;
         }
 
+        // update 0건이면 insert
         long monthlyLimitBytes = resolveMonthlyLimitBytes(payload.familyId(), payload.customerId());
         CustomerQuota customerQuota =
                 CustomerQuota.builder()
@@ -95,6 +101,7 @@ public class UsagePersistService {
         try {
             customerQuotaRepository.saveAndFlush(customerQuota);
         } catch (DataIntegrityViolationException e) {
+            // insert 경합시 실패한 쪽 이벤트 update 재시도
             int retriedRows =
                     customerQuotaRepository.incrementMonthlyUsedBytes(
                             payload.familyId(),
@@ -158,6 +165,7 @@ public class UsagePersistService {
             return currentMonth;
         }
         try {
+            // eventTime이 과도한 과거/미래 월이면 현재 월 fallback (past=1, future=0)
             LocalDate parsedMonth =
                     OffsetDateTime.parse(eventTime)
                             .atZoneSameInstant(KST)
@@ -202,6 +210,7 @@ public class UsagePersistService {
     }
 
     private long resolveMonthlyLimitBytes(Long familyId, Long customerId) {
+        // 이번 달 row가 없어서 insert할때 과거 row 중 가장 최신 monthlyLimitBytes를 넣음
         return customerQuotaRepository
                 .findTopByFamilyIdAndCustomerIdAndDeletedAtIsNullOrderByCurrentMonthDesc(
                         familyId, customerId)

--- a/src/main/java/com/project/domain/usage/service/UsagePersistService.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistService.java
@@ -1,0 +1,130 @@
+package com.project.domain.usage.service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.domain.customer.entity.CustomerQuota;
+import com.project.domain.customer.repository.CustomerQuotaRepository;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsagePersistPayload;
+import com.project.global.util.RedisKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UsagePersistService {
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final RedisTemplate<String, String> familyStringRedisTemplate;
+    private final RedisKeyGenerator redisKeyGenerator;
+    private final UsagePersistEventValidator usagePersistEventValidator;
+    private final CustomerQuotaRepository customerQuotaRepository;
+
+    @Value("${app.kafka.dedup.usage-persist-ttl-seconds}")
+    private long usagePersistDedupTtlSeconds;
+
+    @Transactional
+    public void persist(EventEnvelope<UsagePersistPayload> envelope, String recordKey) {
+        UsagePersistPayload payload = envelope.payload();
+        String eventId = envelope.eventId();
+
+        if (!usagePersistEventValidator.isValidPayload(payload, eventId, recordKey)) {
+            return;
+        }
+
+        if (isDuplicated(payload.originEventId())) {
+            return;
+        }
+
+        LocalDate currentMonth = resolveCurrentMonth(payload.eventTime());
+        int updatedRows =
+                customerQuotaRepository.incrementMonthlyUsedBytes(
+                        payload.familyId(),
+                        payload.customerId(),
+                        currentMonth,
+                        payload.bytesUsed());
+        if (updatedRows > 0) {
+            log.info(
+                    "Persisted usage to existing quota row. eventId={}, originEventId={},"
+                            + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
+                    eventId,
+                    payload.originEventId(),
+                    payload.familyId(),
+                    payload.customerId(),
+                    payload.bytesUsed(),
+                    currentMonth);
+            return;
+        }
+
+        CustomerQuota customerQuota =
+                CustomerQuota.builder()
+                        .familyId(payload.familyId())
+                        .customerId(payload.customerId())
+                        .monthlyUsedBytes(payload.bytesUsed())
+                        .currentMonth(currentMonth)
+                        .monthlyLimitBytes(null)
+                        .isBlocked(false)
+                        .blockReason(null)
+                        .build();
+        customerQuotaRepository.save(customerQuota);
+        log.info(
+                "Persisted usage by creating quota row. eventId={}, originEventId={},"
+                        + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
+                eventId,
+                payload.originEventId(),
+                payload.familyId(),
+                payload.customerId(),
+                payload.bytesUsed(),
+                currentMonth);
+    }
+
+    private boolean isDuplicated(String originEventId) {
+        String dedupKey = redisKeyGenerator.generateUsagePersistEventDedupKey(originEventId);
+        try {
+            Boolean firstSeen =
+                    familyStringRedisTemplate
+                            .opsForValue()
+                            .setIfAbsent(
+                                    dedupKey, "1", Duration.ofSeconds(usagePersistDedupTtlSeconds));
+            if (!Boolean.TRUE.equals(firstSeen)) {
+                log.info("Skip duplicated usage-persist event. originEventId={}", originEventId);
+                return true;
+            }
+            return false;
+        } catch (DataAccessException e) {
+            log.warn(
+                    "Redis dedup failed. Continue DB persist for availability. originEventId={}",
+                    originEventId,
+                    e);
+            return false;
+        }
+    }
+
+    private LocalDate resolveCurrentMonth(String eventTime) {
+        if (eventTime == null || eventTime.isBlank()) {
+            return LocalDate.now(KST).withDayOfMonth(1);
+        }
+        try {
+            return OffsetDateTime.parse(eventTime)
+                    .atZoneSameInstant(KST)
+                    .toLocalDate()
+                    .withDayOfMonth(1);
+        } catch (DateTimeParseException e) {
+            log.warn(
+                    "Invalid eventTime format. Fallback to current month. eventTime={}", eventTime);
+            return LocalDate.now(KST).withDayOfMonth(1);
+        }
+    }
+}

--- a/src/main/java/com/project/domain/usage/service/UsagePersistService.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistService.java
@@ -5,9 +5,11 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +27,14 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class UsagePersistService {
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final String ASIA_SEOUL_TIME_ZONE = "Asia/Seoul";
+    private static final String DEDUP_FLAG = "1";
+    private static final ZoneId KST = ZoneId.of(ASIA_SEOUL_TIME_ZONE);
+    private static final Pattern LOG_DANGEROUS_PATTERN = Pattern.compile("[\\r\\n\\t]");
+    private static final int MAX_LOG_VALUE_LENGTH = 128;
+    private static final long ALLOWED_PAST_MONTHS = 1;
+    private static final long ALLOWED_FUTURE_MONTHS = 0;
+    private static final long SAFE_DEFAULT_MONTHLY_LIMIT_BYTES = 0L;
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
     private final RedisKeyGenerator redisKeyGenerator;
@@ -39,12 +48,14 @@ public class UsagePersistService {
     public void persist(EventEnvelope<UsagePersistPayload> envelope, String recordKey) {
         UsagePersistPayload payload = envelope.payload();
         String eventId = envelope.eventId();
+        String safeEventId = sanitizeForLog(eventId);
+        String safeOriginEventId = sanitizeForLog(payload == null ? null : payload.originEventId());
 
         if (!usagePersistEventValidator.isValidPayload(payload, eventId, recordKey)) {
             return;
         }
 
-        if (isDuplicated(payload.originEventId())) {
+        if (isDuplicated(payload.originEventId(), safeOriginEventId)) {
             return;
         }
 
@@ -59,8 +70,8 @@ public class UsagePersistService {
             log.info(
                     "Persisted usage to existing quota row. eventId={}, originEventId={},"
                             + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
-                    eventId,
-                    payload.originEventId(),
+                    safeEventId,
+                    safeOriginEventId,
                     payload.familyId(),
                     payload.customerId(),
                     payload.bytesUsed(),
@@ -68,63 +79,133 @@ public class UsagePersistService {
             return;
         }
 
+        long monthlyLimitBytes = resolveMonthlyLimitBytes(payload.familyId(), payload.customerId());
         CustomerQuota customerQuota =
                 CustomerQuota.builder()
                         .familyId(payload.familyId())
                         .customerId(payload.customerId())
                         .monthlyUsedBytes(payload.bytesUsed())
                         .currentMonth(currentMonth)
-                        .monthlyLimitBytes(null)
+                        .monthlyLimitBytes(monthlyLimitBytes)
                         .isBlocked(false)
                         .blockReason(null)
                         .build();
-        customerQuotaRepository.save(customerQuota);
+        try {
+            customerQuotaRepository.saveAndFlush(customerQuota);
+        } catch (DataIntegrityViolationException e) {
+            int retriedRows =
+                    customerQuotaRepository.incrementMonthlyUsedBytes(
+                            payload.familyId(),
+                            payload.customerId(),
+                            currentMonth,
+                            payload.bytesUsed());
+            if (retriedRows > 0) {
+                log.info(
+                        "Recovered from concurrent insert race. eventId={}, originEventId={},"
+                                + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
+                        safeEventId,
+                        safeOriginEventId,
+                        payload.familyId(),
+                        payload.customerId(),
+                        payload.bytesUsed(),
+                        currentMonth);
+                return;
+            }
+            throw e;
+        }
+
         log.info(
                 "Persisted usage by creating quota row. eventId={}, originEventId={},"
                         + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
-                eventId,
-                payload.originEventId(),
+                safeEventId,
+                safeOriginEventId,
                 payload.familyId(),
                 payload.customerId(),
                 payload.bytesUsed(),
                 currentMonth);
     }
 
-    private boolean isDuplicated(String originEventId) {
+    private boolean isDuplicated(String originEventId, String safeOriginEventId) {
         String dedupKey = redisKeyGenerator.generateUsagePersistEventDedupKey(originEventId);
         try {
             Boolean firstSeen =
                     familyStringRedisTemplate
                             .opsForValue()
                             .setIfAbsent(
-                                    dedupKey, "1", Duration.ofSeconds(usagePersistDedupTtlSeconds));
+                                    dedupKey,
+                                    DEDUP_FLAG,
+                                    Duration.ofSeconds(usagePersistDedupTtlSeconds));
             if (!Boolean.TRUE.equals(firstSeen)) {
-                log.info("Skip duplicated usage-persist event. originEventId={}", originEventId);
+                log.info(
+                        "Skip duplicated usage-persist event. originEventId={}",
+                        safeOriginEventId);
                 return true;
             }
             return false;
         } catch (DataAccessException e) {
             log.warn(
                     "Redis dedup failed. Continue DB persist for availability. originEventId={}",
-                    originEventId,
+                    safeOriginEventId,
                     e);
             return false;
         }
     }
 
     private LocalDate resolveCurrentMonth(String eventTime) {
+        LocalDate currentMonth = LocalDate.now(KST).withDayOfMonth(1);
         if (eventTime == null || eventTime.isBlank()) {
-            return LocalDate.now(KST).withDayOfMonth(1);
+            return currentMonth;
         }
         try {
-            return OffsetDateTime.parse(eventTime)
+            LocalDate parsedMonth =
+                    OffsetDateTime.parse(eventTime)
                     .atZoneSameInstant(KST)
                     .toLocalDate()
                     .withDayOfMonth(1);
+            if (isOutsideAllowedMonthWindow(parsedMonth, currentMonth)) {
+                log.warn(
+                        "Suspicious eventTime month. Fallback to current month. eventTime={},"
+                                + " parsedMonth={}, currentMonth={}, allowedPastMonths={},"
+                                + " allowedFutureMonths={}",
+                        sanitizeForLog(eventTime),
+                        parsedMonth,
+                        currentMonth,
+                        ALLOWED_PAST_MONTHS,
+                        ALLOWED_FUTURE_MONTHS);
+                return currentMonth;
+            }
+            return parsedMonth;
         } catch (DateTimeParseException e) {
             log.warn(
-                    "Invalid eventTime format. Fallback to current month. eventTime={}", eventTime);
-            return LocalDate.now(KST).withDayOfMonth(1);
+                    "Invalid eventTime format. Fallback to current month. eventTime={}",
+                    sanitizeForLog(eventTime));
+            return currentMonth;
         }
+    }
+
+    private boolean isOutsideAllowedMonthWindow(LocalDate parsedMonth, LocalDate currentMonth) {
+        LocalDate minMonth = currentMonth.minusMonths(ALLOWED_PAST_MONTHS);
+        LocalDate maxMonth = currentMonth.plusMonths(ALLOWED_FUTURE_MONTHS);
+        return parsedMonth.isBefore(minMonth) || parsedMonth.isAfter(maxMonth);
+    }
+
+    private String sanitizeForLog(String raw) {
+        if (raw == null) {
+            return "null";
+        }
+        String sanitized = LOG_DANGEROUS_PATTERN.matcher(raw).replaceAll("_");
+        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
+            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
+        }
+        return sanitized;
+    }
+
+    private long resolveMonthlyLimitBytes(Long familyId, Long customerId) {
+        return customerQuotaRepository
+                .findTopByFamilyIdAndCustomerIdAndDeletedAtIsNullOrderByCurrentMonthDesc(
+                        familyId, customerId)
+                .map(CustomerQuota::getMonthlyLimitBytes)
+                .filter(limit -> limit != null && limit >= 0)
+                .orElse(SAFE_DEFAULT_MONTHLY_LIMIT_BYTES);
     }
 }

--- a/src/main/java/com/project/domain/usage/service/UsagePersistService.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistService.java
@@ -32,6 +32,8 @@ public class UsagePersistService {
     private static final ZoneId KST = ZoneId.of(ASIA_SEOUL_TIME_ZONE);
     private static final Pattern LOG_DANGEROUS_PATTERN = Pattern.compile("[\\r\\n\\t]");
     private static final int MAX_LOG_VALUE_LENGTH = 128;
+    private static final String USAGE_PERSIST_LOG_SUFFIX =
+            " familyId={}, customerId={}, bytesUsed={}, currentMonth={}";
     private static final long ALLOWED_PAST_MONTHS = 1;
     private static final long ALLOWED_FUTURE_MONTHS = 0;
     private static final long SAFE_DEFAULT_MONTHLY_LIMIT_BYTES = 0L;
@@ -69,7 +71,7 @@ public class UsagePersistService {
         if (updatedRows > 0) {
             log.info(
                     "Persisted usage to existing quota row. eventId={}, originEventId={},"
-                            + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
+                            + USAGE_PERSIST_LOG_SUFFIX,
                     safeEventId,
                     safeOriginEventId,
                     payload.familyId(),
@@ -102,7 +104,7 @@ public class UsagePersistService {
             if (retriedRows > 0) {
                 log.info(
                         "Recovered from concurrent insert race. eventId={}, originEventId={},"
-                                + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
+                                + USAGE_PERSIST_LOG_SUFFIX,
                         safeEventId,
                         safeOriginEventId,
                         payload.familyId(),
@@ -116,7 +118,7 @@ public class UsagePersistService {
 
         log.info(
                 "Persisted usage by creating quota row. eventId={}, originEventId={},"
-                        + " familyId={}, customerId={}, bytesUsed={}, currentMonth={}",
+                        + USAGE_PERSIST_LOG_SUFFIX,
                 safeEventId,
                 safeOriginEventId,
                 payload.familyId(),

--- a/src/main/java/com/project/global/event/KafkaEventMessageSupport.java
+++ b/src/main/java/com/project/global/event/KafkaEventMessageSupport.java
@@ -1,0 +1,44 @@
+package com.project.global.event;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.global.event.dto.EventEnvelope;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaEventMessageSupport {
+    private static final String EVENT_TYPE_FIELD = "eventType";
+    private static final int MAX_LOG_VALUE_LENGTH = 128;
+
+    private final ObjectMapper objectMapper;
+
+    public JsonNode readTree(String rawMessage) throws JsonProcessingException {
+        return objectMapper.readTree(rawMessage);
+    }
+
+    public String extractEventType(JsonNode root) {
+        return root.path(EVENT_TYPE_FIELD).asText("");
+    }
+
+    public <T> EventEnvelope<T> convertToEnvelope(
+            JsonNode root, TypeReference<EventEnvelope<T>> typeReference) {
+        return objectMapper.convertValue(root, typeReference);
+    }
+
+    public String sanitizeForLog(String raw) {
+        if (raw == null) {
+            return "null";
+        }
+        String sanitized = raw.replace('\r', '_').replace('\n', '_').replace('\t', '_');
+        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
+            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
+        }
+        return sanitized;
+    }
+}

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -8,6 +8,7 @@ public class RedisKeyGenerator {
     private static final String KEY_SEPARATOR = ":";
     private static final String EXAMPLE_KEY_PREFIX = "example";
     private static final String FAMILY_KEY_PREFIX = "family";
+    private static final String USAGE_PERSIST_EVENT_DEDUP_KEY_PREFIX = "event:dedup:usage-persist";
 
     public String generateExampleKey(Long exampleId) {
         return EXAMPLE_KEY_PREFIX + KEY_SEPARATOR + exampleId;
@@ -37,5 +38,9 @@ public class RedisKeyGenerator {
 
     public String generateFamilyKey(Long familyId) {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId;
+    }
+
+    public String generateUsagePersistEventDedupKey(String originEventId) {
+        return USAGE_PERSIST_EVENT_DEDUP_KEY_PREFIX + KEY_SEPARATOR + originEventId;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,3 +80,8 @@ logging:
     root: INFO
     org.springframework.web: INFO
     org.hibernate.SQL: WARN
+
+app:
+  kafka:
+    dedup:
+      usage-persist-ttl-seconds: ${USAGE_PERSIST_DEDUP_TTL_SECONDS:600}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #5 
- jira: DABOM-147

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->

`processor-usage`에서 `usage-persist` 이벤트를 소비해 `customer_quota.monthly_used_bytes`를 누적 반영한다.
중복 이벤트(`originEventId`) 재처리를 방지하고, 월 계산 기준을 KST(Asia/Seoul)로 통일한다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `usage-persist` Kafka consumer 처리 연결
  - `EventEnvelope<UsagePersistPayload>` 파싱 후 서비스 위임
- payload 유효성 검증 추가
  - 필수값: `originEventId`, `familyId`, `customerId`, `bytesUsed(>0)`
- dedup 처리 추가
  - 키: `event:dedup:usage-persist:{originEventId}`
  - TTL 설정 외부화: `app.kafka.dedup.usage-persist-ttl-seconds` (기본 600초)
- DB 누적 반영 로직 추가
  - `(familyId, customerId, currentMonth)` row 존재 시 `monthly_used_bytes += bytesUsed`
  - row 미존재 시 신규 insert
- 월 계산 규칙 적용
  - `eventTime` 기준 `Asia/Seoul`
- 파싱 실패/누락 시 현재 월 fallback
- 토픽 타입 불일치 예외 처리
  - 컨슈머에서 eventType 검사 후 파싱/처리

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

|  도메인  | controller | service | repository | entity | infra | global |
| :------: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|  usage   |            |    x    |            |        |   x   |        |
| customer |            |         |     x      |        |       |        |
|  global  |            |         |            |        |       |   x    |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```yaml
app:
  kafka:
    dedup:
      policy-ttl-seconds: ${POLICY_DEDUP_TTL_SECONDS:3600}
      usage-persist-ttl-seconds: ${USAGE_PERSIST_DEDUP_TTL_SECONDS:600}
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

- v1은 단순 누적(update-first + insert fallback) 구현이다.
- `originEventId` dedup은 Redis 기반이며, Redis 장애 시 서비스 가용성을 위해 DB 반영은 계속 진행한다.
- out-of-order 보정/정교한 정합성 보정은 후속 이슈에서 다룬다.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**

- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**

- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**

- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
