### PR TITLE
[DABOM-142] 사용량 Kafka 이벤트 수신 및 Redis 동기화 로직 구현

### DIFF
--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageEventsConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageEventsConsumer.java
@@ -31,7 +31,8 @@ public class UsageEventsConsumer {
             // JSON 역직렬화
             EventEnvelope<UsagePayload> envelope =
                     objectMapper.readValue(
-                            consumerRecord.value(), new TypeReference<EventEnvelope<UsagePayload>>() {});
+                            consumerRecord.value(),
+                            new TypeReference<EventEnvelope<UsagePayload>>() {});
 
             eventId = envelope.eventId();
             UsagePayload payload = envelope.payload();

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageEventsConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageEventsConsumer.java
@@ -24,14 +24,14 @@ public class UsageEventsConsumer {
     private final UsageEventValidator validator;
 
     @KafkaListener(topics = "usage-events", groupId = "dabom-processor-usage")
-    public void consume(ConsumerRecord<String, String> record) {
+    public void consume(ConsumerRecord<String, String> consumerRecord) {
         String eventId = "unknown";
 
         try {
             // JSON 역직렬화
             EventEnvelope<UsagePayload> envelope =
                     objectMapper.readValue(
-                            record.value(), new TypeReference<EventEnvelope<UsagePayload>>() {});
+                            consumerRecord.value(), new TypeReference<EventEnvelope<UsagePayload>>() {});
 
             eventId = envelope.eventId();
             UsagePayload payload = envelope.payload();
@@ -40,12 +40,12 @@ public class UsageEventsConsumer {
             if (!validator.isValid(payload, eventId)) {
                 log.warn(
                         "Skipping invalid usage event. Key: {}, EventId: {}",
-                        record.key(),
+                        consumerRecord.key(),
                         eventId);
                 return;
             }
 
-            log.debug("Consumed usage event: {} (Key: {})", eventId, record.key());
+            log.debug("Consumed usage event: {} (Key: {})", eventId, consumerRecord.key());
 
             // 비즈니스 로직 위임
             usageSyncService.syncUsage(eventId, envelope.timestamp().toString(), payload);
@@ -53,7 +53,7 @@ public class UsageEventsConsumer {
             // 에러 발생 시 로그만 남기고 넘김
             log.error(
                     "Failed to process usage event [Key: {}, EventId: {}]: {}",
-                    record.key(),
+                    consumerRecord.key(),
                     eventId,
                     e.getMessage(),
                     e);

--- a/src/main/java/com/project/domain/usage/infra/messaging/UsageEventsConsumer.java
+++ b/src/main/java/com/project/domain/usage/infra/messaging/UsageEventsConsumer.java
@@ -1,0 +1,62 @@
+package com.project.domain.usage.infra.messaging;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.usage.service.UsageEventValidator;
+import com.project.domain.usage.service.UsageSyncService;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsagePayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsageEventsConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final UsageSyncService usageSyncService;
+    private final UsageEventValidator validator;
+
+    @KafkaListener(topics = "usage-events", groupId = "dabom-processor-usage")
+    public void consume(ConsumerRecord<String, String> record) {
+        String eventId = "unknown";
+
+        try {
+            // JSON 역직렬화
+            EventEnvelope<UsagePayload> envelope =
+                    objectMapper.readValue(
+                            record.value(), new TypeReference<EventEnvelope<UsagePayload>>() {});
+
+            eventId = envelope.eventId();
+            UsagePayload payload = envelope.payload();
+
+            // 이벤트 검증
+            if (!validator.isValid(payload, eventId)) {
+                log.warn(
+                        "Skipping invalid usage event. Key: {}, EventId: {}",
+                        record.key(),
+                        eventId);
+                return;
+            }
+
+            log.debug("Consumed usage event: {} (Key: {})", eventId, record.key());
+
+            // 비즈니스 로직 위임
+            usageSyncService.syncUsage(eventId, envelope.timestamp().toString(), payload);
+        } catch (Exception e) {
+            // 에러 발생 시 로그만 남기고 넘김
+            log.error(
+                    "Failed to process usage event [Key: {}, EventId: {}]: {}",
+                    record.key(),
+                    eventId,
+                    e.getMessage(),
+                    e);
+        }
+    }
+}

--- a/src/main/java/com/project/domain/usage/service/UsageEventValidator.java
+++ b/src/main/java/com/project/domain/usage/service/UsageEventValidator.java
@@ -1,0 +1,35 @@
+package com.project.domain.usage.service;
+
+import org.springframework.stereotype.Component;
+
+import com.project.global.event.dto.usage.UsagePayload;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class UsageEventValidator {
+    public boolean isValid(UsagePayload payload, String eventId) {
+        // Payload 자체 null 체크
+        if (payload == null) {
+            log.warn("Usage payload is null. eventId={}", eventId);
+            return false;
+        }
+        // 필수 ID 값 체크 (FamilyId, CustomerId)
+        if (payload.familyId() == null || payload.familyId() <= 0) {
+            log.warn("Invalid familyId. eventId={}, familyId={}", eventId, payload.familyId());
+            return false;
+        }
+        if (payload.customerId() == null || payload.customerId() <= 0) {
+            log.warn(
+                    "Invalid customerId. eventId={}, customerId={}", eventId, payload.customerId());
+            return false;
+        }
+        // 사용량 값 체크 (음수, 0)
+        if (payload.bytesUsed() == null || payload.bytesUsed() < 0) {
+            log.warn("Invalid bytesUsed. eventId={}, bytes={}", eventId, payload.bytesUsed());
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import com.project.domain.notification.infra.messaging.NotificationKafkaProducer;
 import com.project.domain.usage.infra.messaging.UsagePersistKafkaProducer;
 import com.project.domain.usage.infra.messaging.UsageRealtimeKafkaProducer;
+import com.project.domain.usage.service.dto.UsageUpdateResult;
 import com.project.global.event.dto.notification.CustomerBlockedPayload;
 import com.project.global.event.dto.notification.ThresholdAlertPayload;
 import com.project.global.event.dto.usage.UsagePayload;
@@ -61,61 +62,47 @@ public class UsageSyncService {
             return;
         }
 
-        // 결과 파싱
-        long totalUsed = ((Number) result.get(0)).longValue();
-        long remaining = ((Number) result.get(1)).longValue();
-        String status = (String) result.get(2);
-        long monthlyUsed = ((Number) result.get(3)).longValue();
+        UsageUpdateResult parsed = parseScriptResult(result, eventId);
+        log.debug(
+                "Usage Synced: family={}, customer={}, status={}",
+                familyId,
+                customerId,
+                parsed.status());
 
-        Object userRatioObj = result.get(4);
-        double userRatio =
-                (userRatioObj instanceof Number number)
-                        ? number.doubleValue()
-                        : Double.parseDouble(userRatioObj.toString());
-
-        long monthlyLimit = ((Number) result.get(5)).longValue();
-        log.debug("Usage Synced: family={}, customer={}, status={}", familyId, customerId, status);
+        UsageSyncContext ctx = new UsageSyncContext(eventId, eventTime, payload, parsed);
 
         // 이벤트 전파
-        publishEvents(
-                eventId,
-                eventTime,
-                payload,
-                totalUsed,
-                remaining,
-                status,
-                monthlyUsed,
-                userRatio,
-                monthlyLimit);
+        publishEvents(ctx);
     }
 
-    private void publishEvents(
-            String eventId,
-            String eventTime,
-            UsagePayload payload,
-            long totalUsed,
-            long remaining,
-            String status,
-            long monthlyUsed,
-            double userRatio,
-            long monthlyLimit) {
+    private void publishEvents(UsageSyncContext ctx) {
+
+        UsagePayload payload = ctx.payload();
 
         long familyId = payload.familyId();
         long customerId = payload.customerId();
+
+        long totalUsed = ctx.result().totalUsed();
+        long remaining = ctx.result().remaining();
+        String status = ctx.result().status();
+        long monthlyUsed = ctx.result().monthlyUsed();
+        double userRatio = ctx.result().userRatio();
+        long monthlyLimit = ctx.result().monthlyLimit();
+
         long totalLimit = totalUsed + remaining;
         double usedPercent = totalLimit > 0 ? (double) totalUsed / totalLimit * 100.0 : 0.0;
 
         // DB 저장 이벤트 (Persist)
         persistProducer.publish(
                 new UsagePersistPayload(
-                        eventId,
+                        ctx.eventId(),
                         familyId,
                         customerId,
                         payload.bytesUsed(),
                         payload.appId(),
                         status.startsWith("BLOCKED") ? "BLOCKED" : "ALLOWED",
                         remaining,
-                        eventTime));
+                        ctx.eventTime()));
 
         // 실시간 사용량 이벤트 (Realtime)
         realtimeProducer.publish(
@@ -140,7 +127,7 @@ public class UsageSyncService {
         } else if (status.startsWith("BLOCKED")) {
             // reason: BLOCKED_ACCESS, BLOCKED_LIMIT_MONTHLY, BLOCKED_FAMILY_QUOTA
             notificationProducer.publish(
-                    new CustomerBlockedPayload(familyId, customerId, status, eventTime));
+                    new CustomerBlockedPayload(familyId, customerId, status, ctx.eventTime()));
         }
     }
 
@@ -153,4 +140,34 @@ public class UsageSyncService {
             throw new IllegalArgumentException("Invalid warning status format: " + status, e);
         }
     }
+
+    // lua script 결과 파싱
+    private UsageUpdateResult parseScriptResult(List<Object> result, String eventId) {
+        if (result == null || result.size() < 6) {
+            log.error(
+                    "Usage update script returned invalid result. eventId={}, result={}",
+                    eventId,
+                    result);
+            throw new IllegalStateException("Invalid Lua script result");
+        }
+
+        long totalUsed = ((Number) result.get(0)).longValue();
+        long remaining = ((Number) result.get(1)).longValue();
+        String status = (String) result.get(2);
+        long monthlyUsed = ((Number) result.get(3)).longValue();
+
+        Object userRatioObj = result.get(4);
+        double userRatio =
+                (userRatioObj instanceof Number number)
+                        ? number.doubleValue()
+                        : Double.parseDouble(userRatioObj.toString());
+
+        long monthlyLimit = ((Number) result.get(5)).longValue();
+
+        return new UsageUpdateResult(
+                totalUsed, remaining, status, monthlyUsed, userRatio, monthlyLimit);
+    }
+
+    private record UsageSyncContext(
+            String eventId, String eventTime, UsagePayload payload, UsageUpdateResult result) {}
 }

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -36,7 +36,6 @@ public class UsageSyncService {
     // Lua Script
     private final RedisScript<List<Object>> usageUpdateScript;
 
-    @Transactional
     public void syncUsage(String eventId, String eventTime, UsagePayload payload) {
 
         Long familyId = payload.familyId();

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -151,8 +151,8 @@ public class UsageSyncService {
         // "WARNING_10" -> 10
         try {
             return Integer.parseInt(status.split("_")[1]);
-        } catch (Exception e) {
-            return 10; // 기본값
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            throw new IllegalArgumentException("Invalid warning status format: " + status, e);
         }
     }
 }

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -2,10 +2,10 @@ package com.project.domain.usage.service;
 
 import java.util.List;
 
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.notification.infra.messaging.NotificationKafkaProducer;
 import com.project.domain.usage.infra.messaging.UsagePersistKafkaProducer;
@@ -36,36 +36,59 @@ public class UsageSyncService {
     // Lua Script
     private final RedisScript<List<Object>> usageUpdateScript;
 
+    @Transactional
     public void syncUsage(String eventId, String eventTime, UsagePayload payload) {
-        long familyId = payload.familyId();
 
-        // 1. Redis Key 생성
+        Long familyId = payload.familyId();
+        Long customerId = payload.customerId();
+        long usageBytes = payload.bytesUsed();
+
+        // Redis Key 생성
         String infoKey = redisKeyGenerator.generateFamilyInfoKey(familyId);
         String remainingKey = redisKeyGenerator.generateFamilyRemainingKey(familyId);
+        String monthlyKey =
+                redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(familyId, customerId);
+        String constraintsKey =
+                redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
+        String alertsKey = redisKeyGenerator.generateFamilyAlertsKey(familyId);
 
-        // 2. Lua Script 실행 (Atomic Update)
-        // KEYS: [info, remaining], ARGV: [usageBytes]
-        // Result: [totalUsed(Long), remaining(Long), status(String)]
+        // Lua Script 실행
         List<Object> result =
                 redisTemplate.execute(
                         usageUpdateScript,
-                        List.of(infoKey, remainingKey),
-                        String.valueOf(payload.bytesUsed()));
+                        List.of(infoKey, remainingKey, monthlyKey, constraintsKey, alertsKey),
+                        String.valueOf(usageBytes));
+        if (result == null || result.isEmpty()) {
+            log.error("Usage update script returned null. eventId={}", eventId);
+            return;
+        }
 
-        // 3. 결과 파싱
+        // 결과 파싱
         long totalUsed = ((Number) result.get(0)).longValue();
         long remaining = ((Number) result.get(1)).longValue();
         String status = (String) result.get(2);
+        long monthlyUsed = ((Number) result.get(3)).longValue();
 
-        log.debug(
-                "Usage Synced: family={}, used={}, remain={}, status={}",
-                familyId,
+        Object userRatioObj = result.get(4);
+        double userRatio =
+                (userRatioObj instanceof Number)
+                        ? ((Number) userRatioObj).doubleValue()
+                        : Double.parseDouble(userRatioObj.toString());
+
+        long monthlyLimit = ((Number) result.get(5)).longValue();
+        log.debug("Usage Synced: family={}, customer={}, status={}", familyId, customerId, status);
+
+        // 이벤트 전파
+        publishEvents(
+                eventId,
+                eventTime,
+                payload,
                 totalUsed,
                 remaining,
-                status);
-
-        // 4. 이벤트 전파
-        publishEvents(eventId, eventTime, payload, totalUsed, remaining, status);
+                status,
+                monthlyUsed,
+                userRatio,
+                monthlyLimit);
     }
 
     private void publishEvents(
@@ -74,42 +97,52 @@ public class UsageSyncService {
             UsagePayload payload,
             long totalUsed,
             long remaining,
-            String status) {
+            String status,
+            long monthlyUsed,
+            double userRatio,
+            long monthlyLimit) {
 
         long familyId = payload.familyId();
+        long customerId = payload.customerId();
         long totalLimit = totalUsed + remaining;
         double usedPercent = totalLimit > 0 ? (double) totalUsed / totalLimit * 100.0 : 0.0;
 
-        // DB 저장 이벤트 발행
+        // DB 저장 이벤트 (Persist)
         persistProducer.publish(
                 new UsagePersistPayload(
                         eventId,
                         familyId,
-                        payload.customerId(),
+                        customerId,
                         payload.bytesUsed(),
                         payload.appId(),
-                        "BLOCKED".equals(status) ? "BLOCKED" : "ALLOWED",
+                        status.startsWith("BLOCKED") ? "BLOCKED" : "ALLOWED",
                         remaining,
                         eventTime));
 
-        // 사용량 실시간 업데이트 이벤트 발행
+        // 실시간 사용량 이벤트 (Realtime)
         realtimeProducer.publish(
-                new UsageRealtimePayload(familyId, totalUsed, totalLimit, remaining, usedPercent));
+                new UsageRealtimePayload(
+                        familyId,
+                        customerId,
+                        totalUsed,
+                        totalLimit,
+                        remaining,
+                        usedPercent,
+                        monthlyUsed,
+                        userRatio * 100.0,
+                        monthlyLimit));
 
-        // 상태에 따른 알림 발송 이벤트 발행
+        // 알림 이벤트 (Notification)
         if (status.startsWith("WARNING")) {
-
             int percent = parsePercent(status);
-
             notificationProducer.publish(
                     new ThresholdAlertPayload(
-                            familyId,
-                            percent, // 예: 10
-                            "가족 데이터가 " + percent + "% 미만입니다!"));
-        } else if ("BLOCKED".equals(status)) {
+                            familyId, percent, "가족 데이터가 " + percent + "% 미만입니다!"));
+
+        } else if (status.startsWith("BLOCKED")) {
+            // reason: BLOCKED_ACCESS, BLOCKED_LIMIT_MONTHLY, BLOCKED_FAMILY_QUOTA
             notificationProducer.publish(
-                    new CustomerBlockedPayload(
-                            familyId, payload.customerId(), "LIMIT:DATA:MONTHLY", eventTime));
+                    new CustomerBlockedPayload(familyId, customerId, status, eventTime));
         }
     }
 

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -3,6 +3,7 @@ package com.project.domain.usage.service;
 import java.util.List;
 
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
@@ -24,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UsageSyncService {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
     private final RedisKeyGenerator redisKeyGenerator;
 
     // Producers

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.project.domain.notification.infra.messaging.NotificationKafkaProducer;
 import com.project.domain.usage.infra.messaging.UsagePersistKafkaProducer;

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -1,0 +1,124 @@
+package com.project.domain.usage.service;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import com.project.domain.notification.infra.messaging.NotificationKafkaProducer;
+import com.project.domain.usage.infra.messaging.UsagePersistKafkaProducer;
+import com.project.domain.usage.infra.messaging.UsageRealtimeKafkaProducer;
+import com.project.global.event.dto.notification.CustomerBlockedPayload;
+import com.project.global.event.dto.notification.ThresholdAlertPayload;
+import com.project.global.event.dto.usage.UsagePayload;
+import com.project.global.event.dto.usage.UsagePersistPayload;
+import com.project.global.event.dto.usage.UsageRealtimePayload;
+import com.project.global.util.RedisKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UsageSyncService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisKeyGenerator redisKeyGenerator;
+
+    // Producers
+    private final UsagePersistKafkaProducer persistProducer;
+    private final UsageRealtimeKafkaProducer realtimeProducer;
+    private final NotificationKafkaProducer notificationProducer;
+
+    // Lua Script
+    private final RedisScript<List<Object>> usageUpdateScript;
+
+    public void syncUsage(String eventId, String eventTime, UsagePayload payload) {
+        long familyId = payload.familyId();
+
+        // 1. Redis Key 생성
+        String infoKey = redisKeyGenerator.generateFamilyInfoKey(familyId);
+        String remainingKey = redisKeyGenerator.generateFamilyRemainingKey(familyId);
+
+        // 2. Lua Script 실행 (Atomic Update)
+        // KEYS: [info, remaining], ARGV: [usageBytes]
+        // Result: [totalUsed(Long), remaining(Long), status(String)]
+        List<Object> result =
+                redisTemplate.execute(
+                        usageUpdateScript,
+                        List.of(infoKey, remainingKey),
+                        String.valueOf(payload.bytesUsed()));
+
+        // 3. 결과 파싱
+        long totalUsed = ((Number) result.get(0)).longValue();
+        long remaining = ((Number) result.get(1)).longValue();
+        String status = (String) result.get(2);
+
+        log.debug(
+                "Usage Synced: family={}, used={}, remain={}, status={}",
+                familyId,
+                totalUsed,
+                remaining,
+                status);
+
+        // 4. 이벤트 전파
+        publishEvents(eventId, eventTime, payload, totalUsed, remaining, status);
+    }
+
+    private void publishEvents(
+            String eventId,
+            String eventTime,
+            UsagePayload payload,
+            long totalUsed,
+            long remaining,
+            String status) {
+
+        long familyId = payload.familyId();
+        long totalLimit = totalUsed + remaining;
+        double usedPercent = totalLimit > 0 ? (double) totalUsed / totalLimit * 100.0 : 0.0;
+
+        // DB 저장 이벤트 발행
+        persistProducer.publish(
+                new UsagePersistPayload(
+                        eventId,
+                        familyId,
+                        payload.customerId(),
+                        payload.bytesUsed(),
+                        payload.appId(),
+                        "BLOCKED".equals(status) ? "BLOCKED" : "ALLOWED",
+                        remaining,
+                        eventTime));
+
+        // 사용량 실시간 업데이트 이벤트 발행
+        realtimeProducer.publish(
+                new UsageRealtimePayload(familyId, totalUsed, totalLimit, remaining, usedPercent));
+
+        // 상태에 따른 알림 발송 이벤트 발행
+        if (status.startsWith("WARNING")) {
+
+            int percent = parsePercent(status);
+
+            notificationProducer.publish(
+                    new ThresholdAlertPayload(
+                            familyId,
+                            percent, // 예: 10
+                            "가족 데이터가 " + percent + "% 미만입니다!"));
+        } else if ("BLOCKED".equals(status)) {
+            notificationProducer.publish(
+                    new CustomerBlockedPayload(
+                            familyId, payload.customerId(), "LIMIT:DATA:MONTHLY", eventTime));
+        }
+    }
+
+    // 임계치 판정
+    private int parsePercent(String status) {
+        // "WARNING_10" -> 10
+        try {
+            return Integer.parseInt(status.split("_")[1]);
+        } catch (Exception e) {
+            return 10; // 기본값
+        }
+    }
+}

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -69,8 +69,8 @@ public class UsageSyncService {
 
         Object userRatioObj = result.get(4);
         double userRatio =
-                (userRatioObj instanceof Number)
-                        ? ((Number) userRatioObj).doubleValue()
+                (userRatioObj instanceof Number number)
+                        ? number.doubleValue()
                         : Double.parseDouble(userRatioObj.toString());
 
         long monthlyLimit = ((Number) result.get(5)).longValue();

--- a/src/main/java/com/project/domain/usage/service/UsageSyncService.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncService.java
@@ -25,6 +25,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UsageSyncService {
 
+    private static final String STATUS_BLOCKED_PREFIX = "BLOCKED";
+    private static final String STATUS_WARNING_PREFIX = "WARNING";
+
+    private static final String PERSIST_STATUS_BLOCKED = "BLOCKED";
+    private static final String PERSIST_STATUS_ALLOWED = "ALLOWED";
+
     private final StringRedisTemplate redisTemplate;
     private final RedisKeyGenerator redisKeyGenerator;
 
@@ -100,7 +106,9 @@ public class UsageSyncService {
                         customerId,
                         payload.bytesUsed(),
                         payload.appId(),
-                        status.startsWith("BLOCKED") ? "BLOCKED" : "ALLOWED",
+                        status.startsWith(STATUS_BLOCKED_PREFIX)
+                                ? PERSIST_STATUS_BLOCKED
+                                : PERSIST_STATUS_ALLOWED,
                         remaining,
                         ctx.eventTime()));
 
@@ -118,13 +126,13 @@ public class UsageSyncService {
                         monthlyLimit));
 
         // 알림 이벤트 (Notification)
-        if (status.startsWith("WARNING")) {
+        if (status.startsWith(STATUS_WARNING_PREFIX)) {
             int percent = parsePercent(status);
             notificationProducer.publish(
                     new ThresholdAlertPayload(
                             familyId, percent, "가족 데이터가 " + percent + "% 미만입니다!"));
 
-        } else if (status.startsWith("BLOCKED")) {
+        } else if (status.startsWith(STATUS_BLOCKED_PREFIX)) {
             // reason: BLOCKED_ACCESS, BLOCKED_LIMIT_MONTHLY, BLOCKED_FAMILY_QUOTA
             notificationProducer.publish(
                     new CustomerBlockedPayload(familyId, customerId, status, ctx.eventTime()));

--- a/src/main/java/com/project/domain/usage/service/dto/UsageUpdateResult.java
+++ b/src/main/java/com/project/domain/usage/service/dto/UsageUpdateResult.java
@@ -1,0 +1,9 @@
+package com.project.domain.usage.service.dto;
+
+public record UsageUpdateResult(
+        long totalUsed,
+        long remaining,
+        String status,
+        long monthlyUsed,
+        double userRatio,
+        long monthlyLimit) {}

--- a/src/main/java/com/project/global/config/RedisConfig.java
+++ b/src/main/java/com/project/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -86,6 +87,15 @@ public class RedisConfig {
         DefaultRedisScript<List<String>> script = new DefaultRedisScript<>();
         script.setLocation(new ClassPathResource("lua/policy_constraint_update.lua"));
         script.setResultType((Class<List<String>>) (Class<?>) List.class);
+        return script;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public RedisScript<List<Object>> usageUpdateScript() {
+        DefaultRedisScript<List<Object>> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("lua/usage_update.lua"));
+        script.setResultType((Class<List<Object>>) (Class<?>) List.class);
         return script;
     }
 }

--- a/src/main/java/com/project/global/event/dto/usage/UsageRealtimePayload.java
+++ b/src/main/java/com/project/global/event/dto/usage/UsageRealtimePayload.java
@@ -2,7 +2,11 @@ package com.project.global.event.dto.usage;
 
 public record UsageRealtimePayload(
         Long familyId,
-        Long totalUsedBytes,
-        Long totalLimitBytes,
-        Long remainingBytes,
-        Double usedPercent) {}
+        Long customerId,
+        Long totalUsedBytes, // 가족 전체 사용량
+        Long totalLimitBytes, // 가족 전체 할당량
+        Long remainingBytes, // 가족 잔여 데이터
+        Double usedPercent, // 가족 데이터 소진율 (%)
+        Long monthlyUsedBytes, // 개인 월간 사용량
+        Double userUsagePercent, // 개인 기여도 (%)
+        Long monthlyLimitBytes) {}

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -9,7 +9,6 @@ public class RedisKeyGenerator {
     private static final String EXAMPLE_KEY_PREFIX = "example";
     private static final String FAMILY_KEY_PREFIX = "family";
     private static final String POLICY_EVENT_DEDUP_KEY_PREFIX = "event:dedup:policy";
-    private static final String EVENT_DEDUP_KEY_PREFIX = "event:dedup";
 
     public String generateFamilyAlertsKey(Long familyId) {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + "alerts";

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -14,6 +14,7 @@ public class RedisKeyGenerator {
     public String generateFamilyAlertsKey(Long familyId) {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + "alerts";
     }
+
     private static final String USAGE_PERSIST_EVENT_DEDUP_KEY_PREFIX = "event:dedup:usage-persist";
 
     public String generateExampleKey(Long exampleId) {

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -9,6 +9,11 @@ public class RedisKeyGenerator {
     private static final String EXAMPLE_KEY_PREFIX = "example";
     private static final String FAMILY_KEY_PREFIX = "family";
     private static final String POLICY_EVENT_DEDUP_KEY_PREFIX = "event:dedup:policy";
+    private static final String EVENT_DEDUP_KEY_PREFIX = "event:dedup";
+
+    public String generateEventDedupKey(String uuid) {
+        return EVENT_DEDUP_KEY_PREFIX + KEY_SEPARATOR + uuid;
+    }
 
     public String generateExampleKey(Long exampleId) {
         return EXAMPLE_KEY_PREFIX + KEY_SEPARATOR + exampleId;

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -11,8 +11,8 @@ public class RedisKeyGenerator {
     private static final String POLICY_EVENT_DEDUP_KEY_PREFIX = "event:dedup:policy";
     private static final String EVENT_DEDUP_KEY_PREFIX = "event:dedup";
 
-    public String generateEventDedupKey(String uuid) {
-        return EVENT_DEDUP_KEY_PREFIX + KEY_SEPARATOR + uuid;
+    public String generateFamilyAlertsKey(Long familyId) {
+        return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + "alerts";
     }
 
     public String generateExampleKey(Long exampleId) {

--- a/src/main/resources/lua/usage_update.lua
+++ b/src/main/resources/lua/usage_update.lua
@@ -1,0 +1,43 @@
+-- KEYS[1]: family:{fid}:info (Hash)
+-- KEYS[2]: family:{fid}:remaining (String)
+-- ARGV[1]: usageBytes
+
+local infoKey = KEYS[1]
+local remainingKey = KEYS[2]
+local usageBytes = tonumber(ARGV[1])
+
+-- 1. 전체 할당량 조회
+local limitStr = redis.call('HGET', infoKey, 'total_quota')
+local totalLimit = tonumber(limitStr or '0')
+
+-- 2. 현재 잔여량 조회
+local currentRemaining = tonumber(redis.call('GET', remainingKey))
+if currentRemaining == nil then
+    currentRemaining = totalLimit
+end
+
+-- 3. 잔여량 차감
+local newRemaining = redis.call('DECRBY', remainingKey, usageBytes)
+
+-- 4. 상태 판정
+local status = "NORMAL"
+
+if newRemaining <= 0 then
+    status = "BLOCKED"
+else
+    -- 남은 비율 계산
+    local ratio = newRemaining / totalLimit
+
+    if ratio < 0.1 then       -- 10% 미만
+        status = "WARNING_10"
+    elseif ratio < 0.3 then   -- 30% 미만
+        status = "WARNING_30"
+    elseif ratio < 0.5 then   -- 50% 미만
+        status = "WARNING_50"
+    end
+end
+
+-- 5. 총 사용량 계산
+local totalUsed = totalLimit - newRemaining
+
+return {totalUsed, newRemaining, status}

--- a/src/main/resources/lua/usage_update.lua
+++ b/src/main/resources/lua/usage_update.lua
@@ -1,43 +1,106 @@
--- KEYS[1]: family:{fid}:info (Hash)
--- KEYS[2]: family:{fid}:remaining (String)
+-- KEYS[1]: family:{fid}:info
+-- KEYS[2]: family:{fid}:remaining
+-- KEYS[3]: family:{fid}:customer:{uid}:usage:monthly
+-- KEYS[4]: family:{fid}:customer:{uid}:constraints
 -- ARGV[1]: usageBytes
 
-local infoKey = KEYS[1]
-local remainingKey = KEYS[2]
 local usageBytes = tonumber(ARGV[1])
 
--- 1. 전체 할당량 조회
-local limitStr = redis.call('HGET', infoKey, 'total_quota')
-local totalLimit = tonumber(limitStr or '0')
-
--- 2. 현재 잔여량 조회
-local currentRemaining = tonumber(redis.call('GET', remainingKey))
-if currentRemaining == nil then
-    currentRemaining = totalLimit
+-- 1. [Check] 개인 제약 조건 로딩
+local constraints_array = redis.call('HGETALL', KEYS[4])
+local constraints = {}
+for i = 1, #constraints_array, 2 do
+    constraints[constraints_array[i]] = constraints_array[i+1]
 end
 
--- 3. 잔여량 차감
-local newRemaining = redis.call('DECRBY', remainingKey, usageBytes)
+local monthlyLimitStr = constraints['LIMIT:DATA:MONTHLY']
+local monthlyLimit = -1
+if monthlyLimitStr then monthlyLimit = tonumber(monthlyLimitStr) end
 
--- 4. 상태 판정
-local status = "NORMAL"
+local currentMonthly = tonumber(redis.call('GET', KEYS[3]) or '0')
 
-if newRemaining <= 0 then
-    status = "BLOCKED"
-else
-    -- 남은 비율 계산
-    local ratio = newRemaining / totalLimit
+-- (공통 리턴 함수)
+local function getResult(status, currentMonthlyUsed)
+    local totalLimit = tonumber(redis.call('HGET', KEYS[1], 'total_quota') or '0')
+    local currentRemaining = tonumber(redis.call('GET', KEYS[2]) or totalLimit)
+    local totalUsed = totalLimit - currentRemaining
+    local userRatio = 0
+    if totalLimit > 0 then userRatio = currentMonthlyUsed / totalLimit end
 
-    if ratio < 0.1 then       -- 10% 미만
-        status = "WARNING_10"
-    elseif ratio < 0.3 then   -- 30% 미만
-        status = "WARNING_30"
-    elseif ratio < 0.5 then   -- 50% 미만
-        status = "WARNING_50"
+    return {totalUsed, currentRemaining, status, currentMonthlyUsed, userRatio, monthlyLimit}
+end
+
+-- 1. [Block] 완전 차단 여부
+if constraints['BLOCK:ACCESS'] == "1" then
+    return getResult("BLOCKED_ACCESS", currentMonthly)
+end
+
+-- 2. [Limit] 개인 월간 한도 초과 여부
+if monthlyLimit ~= -1 then
+    if (currentMonthly + usageBytes) > monthlyLimit then
+        return getResult("BLOCKED_LIMIT_MONTHLY", currentMonthly)
     end
 end
 
--- 5. 총 사용량 계산
-local totalUsed = totalLimit - newRemaining
+-- 3. [Quota] 가족 잔여량 부족 여부
+local currentRemaining = tonumber(redis.call('GET', KEYS[2]))
+if currentRemaining == nil then
+    local totalLimit = tonumber(redis.call('HGET', KEYS[1], 'total_quota') or '0')
+    currentRemaining = totalLimit
+end
 
-return {totalUsed, newRemaining, status}
+if currentRemaining < usageBytes then
+    return getResult("BLOCKED_FAMILY_QUOTA", currentMonthly)
+end
+
+-- 4. 가족 잔여량 차감
+local newRemaining = redis.call('DECRBY', KEYS[2], usageBytes)
+
+-- 5. 개인 월간 사용량 증가
+local newMonthly = redis.call('INCRBY', KEYS[3], usageBytes)
+
+-- 6. [Result] 상태 판정
+local limitStr = redis.call('HGET', KEYS[1], 'total_quota')
+local totalLimit = tonumber(limitStr or '0')
+local status = "NORMAL"
+
+if newRemaining <= 0 then
+    status = "BLOCKED_FAMILY"
+else
+    local ratio = newRemaining / totalLimit
+
+    -- 현재 도달한 경고 레벨 식별
+    local alertLevel = nil
+    if ratio < 0.1 then
+        alertLevel = "10"
+        status = "WARNING_10"
+    elseif ratio < 0.3 then
+        alertLevel = "30"
+        status = "WARNING_30"
+    elseif ratio < 0.5 then
+        alertLevel = "50"
+        status = "WARNING_50"
+    end
+
+    -- 경고 상태라면 중복 체크
+    if alertLevel then
+        local alertKey = "THRESHOLD:" .. alertLevel
+        -- 이미 알림을 보냈는지 확인
+        local isSent = redis.call('HEXISTS', KEYS[5], alertKey)
+
+        if isSent == 1 then
+            -- 이미 보냈으므로 상태를 NORMAL로 덮어씀
+            status = "NORMAL"
+        else
+            -- 아직 안보냈으면 알림 상태 기록 (PUBLISHED)
+            redis.call('HSET', KEYS[5], alertKey, "PUBLISHED")
+        end
+    end
+end
+
+-- 7. 최종 반환
+local totalUsed = totalLimit - newRemaining
+local userRatio = 0
+if totalLimit > 0 then userRatio = newMonthly / totalLimit end
+
+return {totalUsed, newRemaining, status, newMonthly, userRatio, monthlyLimit}

--- a/src/main/resources/lua/usage_update.lua
+++ b/src/main/resources/lua/usage_update.lua
@@ -67,7 +67,10 @@ local status = "NORMAL"
 if newRemaining <= 0 then
     status = "BLOCKED_FAMILY"
 else
-    local ratio = newRemaining / totalLimit
+    local ratio = 0
+    if totalLimit > 0 then
+        ratio = newRemaining / totalLimit
+    end
 
     -- 현재 도달한 경고 레벨 식별
     local alertLevel = nil

--- a/src/test/java/com/project/domain/usage/infra/messaging/UsageEventsConsumerTest.java
+++ b/src/test/java/com/project/domain/usage/infra/messaging/UsageEventsConsumerTest.java
@@ -70,7 +70,8 @@ class UsageEventsConsumerTest {
     void consume_InvalidPayload() throws JsonProcessingException {
         // given
         String json = "{\"eventId\":\"evt_invalid\", ...}";
-        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, "key", json);
+        ConsumerRecord<String, String> consumerRecord =
+                new ConsumerRecord<>("topic", 0, 0L, "key", json);
 
         EventEnvelope<UsagePayload> envelope =
                 EventEnvelope.of(
@@ -82,7 +83,7 @@ class UsageEventsConsumerTest {
         given(validator.isValid(any(UsagePayload.class), anyString())).willReturn(false);
 
         // when
-        consumer.consume(record);
+        consumer.consume(consumerRecord);
 
         // then
         verify(usageSyncService, never()).syncUsage(any(), any(), any());
@@ -93,14 +94,14 @@ class UsageEventsConsumerTest {
     void consume_DeserializationError() throws JsonProcessingException {
         // given
         String invalidJson = "invalid-json";
-        ConsumerRecord<String, String> record =
+        ConsumerRecord<String, String> consumerRecord =
                 new ConsumerRecord<>("topic", 0, 0L, "key", invalidJson);
 
         given(objectMapper.readValue(eq(invalidJson), any(TypeReference.class)))
                 .willThrow(new RuntimeException("JSON Error"));
 
         // when
-        consumer.consume(record);
+        consumer.consume(consumerRecord);
 
         // then
         verify(usageSyncService, never()).syncUsage(any(), any(), any());

--- a/src/test/java/com/project/domain/usage/infra/messaging/UsageEventsConsumerTest.java
+++ b/src/test/java/com/project/domain/usage/infra/messaging/UsageEventsConsumerTest.java
@@ -42,7 +42,8 @@ class UsageEventsConsumerTest {
     void consume_ValidMessage() throws JsonProcessingException {
         // given
         String json = "{\"eventId\":\"evt_1\", ...}";
-        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, "key", json);
+        ConsumerRecord<String, String> consumerRecord =
+                new ConsumerRecord<>("topic", 0, 0L, "key", json);
 
         EventEnvelope<UsagePayload> envelope =
                 EventEnvelope.of(
@@ -54,7 +55,7 @@ class UsageEventsConsumerTest {
         given(validator.isValid(any(UsagePayload.class), anyString())).willReturn(true);
 
         // when
-        consumer.consume(record);
+        consumer.consume(consumerRecord);
 
         // then
         verify(usageSyncService, times(1))

--- a/src/test/java/com/project/domain/usage/infra/messaging/UsageEventsConsumerTest.java
+++ b/src/test/java/com/project/domain/usage/infra/messaging/UsageEventsConsumerTest.java
@@ -1,0 +1,107 @@
+package com.project.domain.usage.infra.messaging;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.usage.service.UsageEventValidator;
+import com.project.domain.usage.service.UsageSyncService;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsagePayload;
+
+@ExtendWith(MockitoExtension.class)
+class UsageEventsConsumerTest {
+
+    @InjectMocks private UsageEventsConsumer consumer;
+
+    @Mock private ObjectMapper objectMapper;
+
+    @Mock private UsageSyncService usageSyncService;
+
+    @Mock private UsageEventValidator validator;
+
+    @Test
+    @DisplayName("유효한 메시지는 검증 후 서비스를 호출해야 한다")
+    void consume_ValidMessage() throws JsonProcessingException {
+        // given
+        String json = "{\"eventId\":\"evt_1\", ...}";
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, "key", json);
+
+        EventEnvelope<UsagePayload> envelope =
+                EventEnvelope.of(
+                        "USAGE", new UsagePayload("evt_1", 100L, 1L, "app", 100L, Map.of()));
+
+        // Mocking
+        given(objectMapper.readValue(eq(json), any(TypeReference.class))).willReturn(envelope);
+
+        given(validator.isValid(any(UsagePayload.class), anyString())).willReturn(true);
+
+        // when
+        consumer.consume(record);
+
+        // then
+        verify(usageSyncService, times(1))
+                .syncUsage(
+                        eq(envelope.eventId()),
+                        anyString(), // timestamp string
+                        any(UsagePayload.class));
+    }
+
+    @Test
+    @DisplayName("Validator가 실패하면 서비스를 호출하지 않아야 한다")
+    void consume_InvalidPayload() throws JsonProcessingException {
+        // given
+        String json = "{\"eventId\":\"evt_invalid\", ...}";
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, "key", json);
+
+        EventEnvelope<UsagePayload> envelope =
+                EventEnvelope.of(
+                        "USAGE", new UsagePayload("evt_invalid", null, null, null, null, null));
+
+        given(objectMapper.readValue(eq(json), any(TypeReference.class))).willReturn(envelope);
+
+        // Validator returns false
+        given(validator.isValid(any(UsagePayload.class), anyString())).willReturn(false);
+
+        // when
+        consumer.consume(record);
+
+        // then
+        verify(usageSyncService, never()).syncUsage(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("JSON 역직렬화 실패 시 예외를 잡고 서비스를 호출하지 않아야 한다")
+    void consume_DeserializationError() throws JsonProcessingException {
+        // given
+        String invalidJson = "invalid-json";
+        ConsumerRecord<String, String> record =
+                new ConsumerRecord<>("topic", 0, 0L, "key", invalidJson);
+
+        given(objectMapper.readValue(eq(invalidJson), any(TypeReference.class)))
+                .willThrow(new RuntimeException("JSON Error"));
+
+        // when
+        consumer.consume(record);
+
+        // then
+        verify(usageSyncService, never()).syncUsage(any(), any(), any());
+    }
+}

--- a/src/test/java/com/project/domain/usage/service/UsageEventValidatorTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsageEventValidatorTest.java
@@ -1,0 +1,57 @@
+package com.project.domain.usage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.project.global.event.dto.usage.UsagePayload;
+
+class UsageEventValidatorTest {
+
+    private final UsageEventValidator validator = new UsageEventValidator();
+
+    @Test
+    @DisplayName("유효한 페이로드는 검증을 통과해야 한다")
+    void validPayload() {
+        // given
+        UsagePayload payload = new UsagePayload("evt_1", 100L, 1L, "com.app.test", 1024L, Map.of());
+
+        // when
+        boolean result = validator.isValid(payload, "evt_1");
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("필수 값이 누락되면 검증 실패해야 한다")
+    void invalidPayload() {
+        // given
+        UsagePayload payload = new UsagePayload("evt_1", null, null, null, null, null);
+
+        // when
+        boolean result = validator.isValid(payload, "evt_1");
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("음수 사용량은 검증 실패해야 한다")
+    void negativeBytesUsed() {
+        // given
+        UsagePayload payload =
+                new UsagePayload(
+                        "evt_1", 100L, 1L, "appId", -1L, // 음수
+                        Map.of());
+
+        // when
+        boolean result = validator.isValid(payload, "evt_1");
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/project/domain/usage/service/UsageSyncServiceTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsageSyncServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 
 import com.project.domain.notification.infra.messaging.NotificationKafkaProducer;
@@ -36,7 +36,7 @@ class UsageSyncServiceTest {
 
     @InjectMocks private UsageSyncService usageSyncService;
 
-    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private StringRedisTemplate redisTemplate;
 
     @Mock private RedisKeyGenerator redisKeyGenerator;
 

--- a/src/test/java/com/project/domain/usage/service/UsageSyncServiceTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsageSyncServiceTest.java
@@ -1,0 +1,135 @@
+package com.project.domain.usage.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import com.project.domain.notification.infra.messaging.NotificationKafkaProducer;
+import com.project.domain.usage.infra.messaging.UsagePersistKafkaProducer;
+import com.project.domain.usage.infra.messaging.UsageRealtimeKafkaProducer;
+import com.project.global.event.dto.notification.CustomerBlockedPayload;
+import com.project.global.event.dto.notification.ThresholdAlertPayload;
+import com.project.global.event.dto.usage.UsagePayload;
+import com.project.global.event.dto.usage.UsagePersistPayload;
+import com.project.global.event.dto.usage.UsageRealtimePayload;
+import com.project.global.util.RedisKeyGenerator;
+
+@ExtendWith(MockitoExtension.class)
+class UsageSyncServiceTest {
+
+    @InjectMocks private UsageSyncService usageSyncService;
+
+    @Mock private RedisTemplate<String, String> redisTemplate;
+
+    @Mock private RedisKeyGenerator redisKeyGenerator;
+
+    @Mock private UsagePersistKafkaProducer persistProducer;
+
+    @Mock private UsageRealtimeKafkaProducer realtimeProducer;
+
+    @Mock private NotificationKafkaProducer notificationProducer;
+
+    @Mock private RedisScript<List<Object>> usageUpdateScript;
+
+    @Test
+    @DisplayName("정상 상태일 때는 Persist와 Realtime 이벤트만 발행되어야 한다")
+    void syncUsage_Normal() {
+        // given
+        String eventId = "evt_1";
+        String eventTime = LocalDateTime.now().toString();
+        UsagePayload payload = new UsagePayload(eventId, 100L, 1L, "appId", 1024L, Map.of());
+
+        given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
+        given(redisKeyGenerator.generateFamilyRemainingKey(100L))
+                .willReturn("family:100:remaining");
+
+        // Mock Lua Script Result: [totalUsed, remaining, status]
+        List<Object> scriptResult = List.of(5000L, 5000L, "NORMAL");
+
+        // RedisTemplate execute mocking
+        // 주의: varargs 매칭 등 까다로운 부분은 any() 사용 권장
+        given(redisTemplate.execute(eq(usageUpdateScript), anyList(), any(Object.class)))
+                .willReturn(scriptResult);
+
+        // when
+        usageSyncService.syncUsage(eventId, eventTime, payload);
+
+        // then
+        // 1. Persist 발행 확인
+        verify(persistProducer, times(1)).publish(any(UsagePersistPayload.class));
+
+        // 2. Realtime 발행 확인
+        verify(realtimeProducer, times(1)).publish(any(UsageRealtimePayload.class));
+
+        // 3. Notification 발행 안 함 확인
+        verify(notificationProducer, never()).publish(any(ThresholdAlertPayload.class));
+        verify(notificationProducer, never()).publish(any(CustomerBlockedPayload.class));
+    }
+
+    @Test
+    @DisplayName("WARNING 상태일 때는 ThresholdAlertPayload가 발행되어야 한다")
+    void syncUsage_Warning() {
+        // given
+        String eventId = "evt_2";
+        String eventTime = LocalDateTime.now().toString();
+        UsagePayload payload = new UsagePayload(eventId, 100L, 1L, "appId", 1024L, Map.of());
+
+        given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
+        given(redisKeyGenerator.generateFamilyRemainingKey(100L))
+                .willReturn("family:100:remaining");
+
+        // Status: WARNING_10 (10% 남음)
+        List<Object> scriptResult = List.of(9000L, 1000L, "WARNING_10");
+
+        given(redisTemplate.execute(eq(usageUpdateScript), anyList(), any(Object.class)))
+                .willReturn(scriptResult);
+
+        // when
+        usageSyncService.syncUsage(eventId, eventTime, payload);
+
+        // then
+        verify(notificationProducer, times(1)).publish(any(ThresholdAlertPayload.class));
+    }
+
+    @Test
+    @DisplayName("BLOCKED 상태일 때는 CustomerBlockedPayload가 발행되어야 한다")
+    void syncUsage_Blocked() {
+        // given
+        String eventId = "evt_3";
+        String eventTime = LocalDateTime.now().toString();
+        UsagePayload payload = new UsagePayload(eventId, 100L, 1L, "appId", 1024L, Map.of());
+
+        given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
+        given(redisKeyGenerator.generateFamilyRemainingKey(100L))
+                .willReturn("family:100:remaining");
+
+        // Status: BLOCKED
+        List<Object> scriptResult = List.of(10000L, 0L, "BLOCKED");
+
+        given(redisTemplate.execute(eq(usageUpdateScript), anyList(), any(Object.class)))
+                .willReturn(scriptResult);
+
+        // when
+        usageSyncService.syncUsage(eventId, eventTime, payload);
+
+        // then
+        verify(notificationProducer, times(1)).publish(any(CustomerBlockedPayload.class));
+    }
+}

--- a/src/test/java/com/project/domain/usage/service/UsageSyncServiceTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsageSyncServiceTest.java
@@ -56,12 +56,18 @@ class UsageSyncServiceTest {
         String eventTime = LocalDateTime.now().toString();
         UsagePayload payload = new UsagePayload(eventId, 100L, 1L, "appId", 1024L, Map.of());
 
+        // Key Mocking
         given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
         given(redisKeyGenerator.generateFamilyRemainingKey(100L))
                 .willReturn("family:100:remaining");
+        given(redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(100L, 1L))
+                .willReturn("monthlyKey");
+        given(redisKeyGenerator.generateFamilyCustomerConstraintsKey(100L, 1L))
+                .willReturn("constraintsKey");
+        given(redisKeyGenerator.generateFamilyAlertsKey(100L)).willReturn("alertsKey");
 
-        // Mock Lua Script Result: [totalUsed, remaining, status]
-        List<Object> scriptResult = List.of(5000L, 5000L, "NORMAL");
+        // Mock Lua Result: [totalUsed, remaining, status, monthlyUsed, userRatio, monthlyLimit]
+        List<Object> scriptResult = List.of(5000L, 5000L, "NORMAL", 1000L, 0.1, 10000L);
 
         // RedisTemplate execute mocking
         // 주의: varargs 매칭 등 까다로운 부분은 any() 사용 권장
@@ -94,9 +100,15 @@ class UsageSyncServiceTest {
         given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
         given(redisKeyGenerator.generateFamilyRemainingKey(100L))
                 .willReturn("family:100:remaining");
+        given(redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(100L, 1L))
+                .willReturn("monthlyKey");
+        given(redisKeyGenerator.generateFamilyCustomerConstraintsKey(100L, 1L))
+                .willReturn("constraintsKey");
+        given(redisKeyGenerator.generateFamilyAlertsKey(100L)).willReturn("alertsKey");
 
         // Status: WARNING_10 (10% 남음)
-        List<Object> scriptResult = List.of(9000L, 1000L, "WARNING_10");
+        // [totalUsed, remaining, status, monthlyUsed, userRatio, monthlyLimit]
+        List<Object> scriptResult = List.of(9000L, 1000L, "WARNING_10", 2000L, 0.2, 10000L);
 
         given(redisTemplate.execute(eq(usageUpdateScript), anyList(), any(Object.class)))
                 .willReturn(scriptResult);
@@ -119,9 +131,16 @@ class UsageSyncServiceTest {
         given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
         given(redisKeyGenerator.generateFamilyRemainingKey(100L))
                 .willReturn("family:100:remaining");
+        given(redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(100L, 1L))
+                .willReturn("monthlyKey");
+        given(redisKeyGenerator.generateFamilyCustomerConstraintsKey(100L, 1L))
+                .willReturn("constraintsKey");
+        given(redisKeyGenerator.generateFamilyAlertsKey(100L)).willReturn("alertsKey");
 
-        // Status: BLOCKED
-        List<Object> scriptResult = List.of(10000L, 0L, "BLOCKED");
+        // Status: BLOCKED_LIMIT_MONTHLY
+        // [totalUsed, remaining, status, monthlyUsed, userRatio, monthlyLimit]
+        List<Object> scriptResult =
+                List.of(8000L, 2000L, "BLOCKED_LIMIT_MONTHLY", 10001L, 1.0, 10000L);
 
         given(redisTemplate.execute(eq(usageUpdateScript), anyList(), any(Object.class)))
                 .willReturn(scriptResult);


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #1 
- jira: DABOM-142

---

## 🎯 목적

- Kafka로부터 수신된 `DATA_USAGE` 이벤트를 실시간으로 처리하여 정책을 검증하고 가족별 데이터 사용량을 Redis에 동기화합니다.
- 사용량이 변화하면 사용량 저장 이벤트를 발행합니다.
- 실시간 대시보드를 위한 실시간 사용량 이벤트를 발행합니다.
- 데이터 사용량 임계치(10% 미만 등) 도달 시 알림을 발송하고, 데이터 소진 시 차단 이벤트를 발행합니다.
- Redis Lua Script 내에서 알림 중복 발송을 방지합니다.

## 📝 변경 사항

- **UsageEventsConsumer**: Kafka Listener 구현 (JSON 역직렬화 및 유효성 검증)
- **UsageSyncService**: Redis Lua 스크립트를 활용한 원자적(Atomic) 사용량 차감 및 상태 관리
- **UsageEventValidator**: 이벤트 필드 검증 로직 분리
- **usage_update.lua**: Redis 내에서 조회 및 갱신을 한 번에 처리하는 스크립트 작성
- UsageRealtimePayload: 개인 ID(customerId), 월간 사용량, 한도, 기여도 필드 추가
- **단위 테스트**: Consumer, Service, Validator에 대한 검증 코드 작성

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| usage  |            |    x  |            |        |  x  |  x   |

---

## 🖥️ 주요 코드 설명

**Redis Lua Script (Atomic Update)**
```lua
-- 경고 상태라면 중복 체크
    if alertLevel then
        local alertKey = "THRESHOLD:" .. alertLevel
        -- 이미 알림을 보냈는지 확인
        local isSent = redis.call('HEXISTS', KEYS[5], alertKey)

        if isSent == 1 then
            -- 이미 보냈으므로 상태를 NORMAL로 덮어씀
            status = "NORMAL"
        else
            -- 아직 안보냈으면 알림 상태 기록 (PUBLISHED)
            redis.call('HSET', KEYS[5], alertKey, "PUBLISHED")
        end
    end
```

## 💬 리뷰어에게

- Integration Test 제외: UsageEventsConsumerIntegrationTest는 테스트 환경 구성 이슈로 제외하였습니다. 핵심 로직은 단위 테스트(UsageEventsConsumerTest, UsageSyncServiceTest)로 검증 완료하였습니다.
- **Redis Key 구조**: 
    - `family:{id}:info` (가족 정보)
    - `family:{id}:remaining` (잔여량)
    - `family:{id}:customer:{uid}:usage:monthly` (개인 월간 사용량)
    - `family:{id}:customer:{uid}:constraints` (개인 제약 정책)
    - `family:{id}:alerts` (알림 상태 해시)

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- Redis key를 한번 개편할 필요성이 보입니다.
- Redis에 필요한 값이 존재하지 않을 때 DB에서 값을 가져오는 로직(Cache Miss Handling)은 추후 고도화 예정입니다.
