### PR TITLE
[DABOM-187] Redis 실패 시 상세 로그 추가

### DIFF
--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
@@ -12,6 +12,8 @@ import com.project.domain.family.entity.FamilyMember;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.policy.PolicyUpdatedPayload;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.PolicyErrorCode;
 import com.project.global.util.RedisKeyGenerator;
 
 import lombok.RequiredArgsConstructor;
@@ -168,7 +170,7 @@ public class PolicyConstraintSyncService {
                     sanitizeForLog(policyKey),
                     sanitizeForLog(newValue),
                     e);
-            throw e;
+            throw new ApplicationException(PolicyErrorCode.POLICY_REDIS_SYNC_FAILED);
         }
         if (result == null || result.isEmpty()) {
             log.error(
@@ -177,7 +179,7 @@ public class PolicyConstraintSyncService {
                     familyId,
                     customerId,
                     sanitizeForLog(policyKey));
-            throw new IllegalStateException("Redis Lua returned empty result");
+            throw new ApplicationException(PolicyErrorCode.POLICY_REDIS_INVALID_RESULT);
         }
 
         return result.get(0);

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PolicyConstraintSyncService {
     private static final String VALUE_LOG_SUFFIX = ", value={}";
+    private static final int MAX_LOG_VALUE_LENGTH = 128;
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
     private final RedisScript<List<String>> policyConstraintUpdateScript;
@@ -146,18 +147,40 @@ public class PolicyConstraintSyncService {
                 redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
         String normalizedNewValue = (newValue == null || newValue.isBlank()) ? "" : newValue;
 
-        List<String> result =
-                familyStringRedisTemplate.execute(
-                        policyConstraintUpdateScript,
-                        List.of(dedupKey, constraintsKey),
-                        String.valueOf(dedupTtlSeconds),
-                        policyKey,
-                        normalizedNewValue,
-                        String.valueOf(eventVersion));
-        if (result == null || result.isEmpty()) {
-            return "UNKNOWN";
+        List<String> result;
+        try {
+            result =
+                    familyStringRedisTemplate.execute(
+                            policyConstraintUpdateScript,
+                            List.of(dedupKey, constraintsKey),
+                            String.valueOf(dedupTtlSeconds),
+                            policyKey,
+                            normalizedNewValue,
+                            String.valueOf(eventVersion));
+        } catch (Exception e) {
+            log.error(
+                    "Failed to sync policy constraint to Redis. eventId={}, familyId={},"
+                            + " customerId={}, field={}"
+                            + VALUE_LOG_SUFFIX,
+                    sanitizeForLog(eventId),
+                    familyId,
+                    customerId,
+                    sanitizeForLog(policyKey),
+                    sanitizeForLog(newValue),
+                    e);
+            throw e;
         }
-        return String.valueOf(result.get(0));
+        if (result == null || result.isEmpty()) {
+            log.error(
+                    "Invalid Redis Lua result. eventId={}, familyId={}, customerId={}, field={}",
+                    sanitizeForLog(eventId),
+                    familyId,
+                    customerId,
+                    sanitizeForLog(policyKey));
+            throw new IllegalStateException("Redis Lua returned empty result");
+        }
+
+        return result.get(0);
     }
 
     private long resolveEventVersion(EventEnvelope<PolicyUpdatedPayload> envelope) {
@@ -194,5 +217,16 @@ public class PolicyConstraintSyncService {
                 customerId,
                 policyKey,
                 result);
+    }
+
+    private String sanitizeForLog(String raw) {
+        if (raw == null) {
+            return "null";
+        }
+        String sanitized = raw.replace('\r', '_').replace('\n', '_').replace('\t', '_');
+        if (sanitized.length() > MAX_LOG_VALUE_LENGTH) {
+            return sanitized.substring(0, MAX_LOG_VALUE_LENGTH) + "...";
+        }
+        return sanitized;
     }
 }

--- a/src/main/java/com/project/global/exception/code/PolicyErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/PolicyErrorCode.java
@@ -10,7 +10,11 @@ import lombok.RequiredArgsConstructor;
 public enum PolicyErrorCode implements BaseErrorCode {
     POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY_001", "정책을 찾을 수 없습니다"),
     POLICY_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY_002", "해당 정책 할당을 찾을 수 없습니다"),
-    POLICY_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "POLICY_003", "수정할 수 없는 정책입니다");
+    POLICY_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "POLICY_003", "수정할 수 없는 정책입니다"),
+    POLICY_REDIS_SYNC_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR, "POLICY_004", "정책 변경사항을 레디스에 반영하지 못했습니다."),
+    POLICY_REDIS_INVALID_RESULT(
+            HttpStatus.INTERNAL_SERVER_ERROR, "POLICY_005", "유효하지 않은 Redis Lua 스크립트 결과입니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #14 
- jira: DABOM-187

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
policy-update에 한해 v1에서는 Redis 조회 실패 시 로그 처리만 한다

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- Redis 실패 시 상세 로그 추가

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|        |            |         |            |        |       |        |

---

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
