### PR TITLE
[DABOM-230] policy-updated 정책 덮어쓰기 로직 구현

### DIFF
--- a/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import com.project.domain.customer.enums.RoleType;
 import com.project.domain.family.entity.FamilyMember;
 
 public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long> {
@@ -15,9 +14,10 @@ public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long
         Long getCustomerId();
     }
 
-    List<FamilyMember> findAllByFamilyId(Long familyId);
-
-    List<FamilyMember> findAllByFamilyIdAndDeletedAtIsNull(Long familyId);
+    @Query(
+            "select f.familyId as familyId, f.customerId as customerId "
+                    + "from FamilyMember f where f.familyId = :familyId and f.deletedAt is null")
+    List<FamilyMemberTargetProjection> findAllActiveTargetsByFamilyId(Long familyId);
 
     @Query(
             "select f.familyId as familyId, f.customerId as customerId "
@@ -25,7 +25,4 @@ public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long
     List<FamilyMemberTargetProjection> findAllActiveTargets();
 
     boolean existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(Long familyId, Long customerId);
-
-    @Query("select f.role from FamilyMember f where f.customerId = :customerId")
-    RoleType findRoleById(Long customerId);
 }

--- a/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyMemberRepository.java
@@ -9,9 +9,20 @@ import com.project.domain.customer.enums.RoleType;
 import com.project.domain.family.entity.FamilyMember;
 
 public interface FamilyMemberRepository extends JpaRepository<FamilyMember, Long> {
+    interface FamilyMemberTargetProjection {
+        Long getFamilyId();
+
+        Long getCustomerId();
+    }
+
     List<FamilyMember> findAllByFamilyId(Long familyId);
 
     List<FamilyMember> findAllByFamilyIdAndDeletedAtIsNull(Long familyId);
+
+    @Query(
+            "select f.familyId as familyId, f.customerId as customerId "
+                    + "from FamilyMember f where f.deletedAt is null")
+    List<FamilyMemberTargetProjection> findAllActiveTargets();
 
     boolean existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(Long familyId, Long customerId);
 

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncService {
     private static final String VALUE_LOG_SUFFIX = ", value={}";
     private static final String LUA_RESULT_APPLIED = "APPLIED";
+    private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
     private final RedisTemplate<String, String> familyStringRedisTemplate;
     private final RedisScript<List<String>> policyConstraintUpdateScript;
@@ -395,7 +396,7 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
             return System.currentTimeMillis();
         }
         // timestamp를 KST 기준 epoch millis로 변환해 Lua 버전 비교에 사용
-        return envelope.timestamp().atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli();
+        return envelope.timestamp().atZone(ASIA_SEOUL).toInstant().toEpochMilli();
     }
 
     private void logResult(

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
@@ -83,6 +83,12 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
             return;
         }
 
+        // familyId/targetCustomerId가 모두 없으면 전체 활성 구성원에 대해 정책을 반영
+        if (payload.familyId() == null && targetCustomerId == null) {
+            processGlobalPolicyUpdate(eventId, policyKey, eventVersion, normalizedPolicyValue);
+            return;
+        }
+
         // targetCustomerId가 있으면 해당 customer만 반영
         if (targetCustomerId != null) {
             // family-customer 소속 관계 검증
@@ -137,6 +143,43 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
                         + VALUE_LOG_SUFFIX,
                 logSanitizer.sanitize(eventId),
                 payload.familyId(),
+                appliedCount,
+                skippedCount,
+                logSanitizer.sanitize(policyKey),
+                logSanitizer.sanitize(normalizedPolicyValue.normalizedNewValue()));
+    }
+
+    private void processGlobalPolicyUpdate(
+            String eventId,
+            String policyKey,
+            long eventVersion,
+            NormalizedPolicyValue normalizedPolicyValue) {
+        List<FamilyMemberRepository.FamilyMemberTargetProjection> members =
+                familyMemberRepository.findAllActiveTargets();
+        int appliedCount = 0;
+        int skippedCount = 0;
+
+        for (FamilyMemberRepository.FamilyMemberTargetProjection member : members) {
+            boolean applied =
+                    processCustomerPolicyUpdate(
+                            eventId,
+                            member.getFamilyId(),
+                            member.getCustomerId(),
+                            policyKey,
+                            eventVersion,
+                            normalizedPolicyValue);
+            if (applied) {
+                appliedCount++;
+            } else {
+                skippedCount++;
+            }
+        }
+
+        log.info(
+                "Processed global constraint. eventId={}, appliedCount={}, skippedCount={},"
+                        + " field={}"
+                        + VALUE_LOG_SUFFIX,
+                logSanitizer.sanitize(eventId),
                 appliedCount,
                 skippedCount,
                 logSanitizer.sanitize(policyKey),

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
-import com.project.domain.family.entity.FamilyMember;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.policy.constant.PolicyConstraintKeyConstants;
 import com.project.domain.policy.service.helper.PolicyConstraintEventMapper;
@@ -115,17 +114,17 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
         }
 
         // targetCustomerId가 없으면 family 전체(active customer)에게 반영
-        List<FamilyMember> customers =
-                familyMemberRepository.findAllByFamilyIdAndDeletedAtIsNull(payload.familyId());
+        List<FamilyMemberRepository.FamilyMemberTargetProjection> customers =
+                familyMemberRepository.findAllActiveTargetsByFamilyId(payload.familyId());
         int appliedCount = 0;
         int skippedCount = 0;
 
         // family 구성원 단위로 동일 정책을 순차 반영
-        for (FamilyMember customer : customers) {
+        for (FamilyMemberRepository.FamilyMemberTargetProjection customer : customers) {
             boolean applied =
                     processCustomerPolicyUpdate(
                             eventId,
-                            payload.familyId(),
+                            customer.getFamilyId(),
                             customer.getCustomerId(),
                             policyKey,
                             eventVersion,

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.ZoneId;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -155,24 +156,26 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
             NormalizedPolicyValue normalizedPolicyValue) {
         List<FamilyMemberRepository.FamilyMemberTargetProjection> members =
                 familyMemberRepository.findAllActiveTargets();
-        int appliedCount = 0;
-        int skippedCount = 0;
+        AtomicInteger appliedCount = new AtomicInteger(0);
+        AtomicInteger skippedCount = new AtomicInteger(0);
 
-        for (FamilyMemberRepository.FamilyMemberTargetProjection member : members) {
-            boolean applied =
-                    processCustomerPolicyUpdate(
-                            eventId,
-                            member.getFamilyId(),
-                            member.getCustomerId(),
-                            policyKey,
-                            eventVersion,
-                            normalizedPolicyValue);
-            if (applied) {
-                appliedCount++;
-            } else {
-                skippedCount++;
-            }
-        }
+        members.parallelStream()
+                .forEach(
+                        member -> {
+                            boolean applied =
+                                    processCustomerPolicyUpdate(
+                                            eventId,
+                                            member.getFamilyId(),
+                                            member.getCustomerId(),
+                                            policyKey,
+                                            eventVersion,
+                                            normalizedPolicyValue);
+                            if (applied) {
+                                appliedCount.incrementAndGet();
+                            } else {
+                                skippedCount.incrementAndGet();
+                            }
+                        });
 
         log.info(
                 "Processed global constraint. eventId={}, appliedCount={}, skippedCount={},"

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
@@ -243,6 +242,7 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
             // BLOCK:APP은 현재 Redis 상태와 목표 앱 목록을 diff로 동기화
             boolean changed =
                     syncBlockedAppsToCustomer(
+                            eventId,
                             familyId,
                             customerId,
                             normalizedPolicyValue.normalizedBlockedApps(),
@@ -277,7 +277,11 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
     }
 
     private boolean syncBlockedAppsToCustomer(
-            Long familyId, Long customerId, Set<String> desiredBlockedApps, long eventVersion) {
+            String eventId,
+            Long familyId,
+            Long customerId,
+            Set<String> desiredBlockedApps,
+            long eventVersion) {
         // 현재 Redis에 저장된 앱 차단 필드(BLOCK:APP:{appId})를 조회
         String constraintsKey =
                 redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
@@ -294,24 +298,40 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
             return false;
         }
 
-        HashOperations<String, Object, Object> hashOps = familyStringRedisTemplate.opsForHash();
-        String version = String.valueOf(eventVersion);
+        int appliedCount = 0;
 
-        // 제거 대상은 앱 필드와 버전 필드를 함께 삭제
+        // 앱별 Lua 실행으로 dedup/stale/version 검증을 동일하게 적용
         for (String appId : appsToDelete) {
             String appField = PolicyConstraintKeyConstants.BLOCK_APP_PREFIX + appId;
-            hashOps.delete(constraintsKey, appField);
-            hashOps.delete(constraintsKey, buildVersionField(appField));
+            String result =
+                    applyConstraintToCustomer(
+                            eventId + ":" + appField,
+                            eventVersion,
+                            familyId,
+                            customerId,
+                            appField,
+                            null);
+            if (LUA_RESULT_APPLIED.equals(result)) {
+                appliedCount++;
+            }
         }
 
-        // 추가 대상은 앱 필드("1") 저장 + 버전 필드 갱신
         for (String appId : appsToAdd) {
             String appField = PolicyConstraintKeyConstants.BLOCK_APP_PREFIX + appId;
-            hashOps.put(constraintsKey, appField, "1");
-            hashOps.put(constraintsKey, buildVersionField(appField), version);
+            String result =
+                    applyConstraintToCustomer(
+                            eventId + ":" + appField,
+                            eventVersion,
+                            familyId,
+                            customerId,
+                            appField,
+                            "1");
+            if (LUA_RESULT_APPLIED.equals(result)) {
+                appliedCount++;
+            }
         }
 
-        return true;
+        return appliedCount > 0;
     }
 
     private Set<String> loadBlockedApps(String constraintsKey) {
@@ -330,11 +350,6 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
                                         PolicyConstraintKeyConstants.BLOCK_APP_PREFIX.length()))
                 .filter(appId -> !appId.isBlank())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    private String buildVersionField(String policyKey) {
-        // Lua 버전 비교와 동일 규칙(ver:{field})을 맞춰 버전 필드를 생성
-        return PolicyConstraintKeyConstants.VERSION_FIELD_PREFIX + policyKey;
     }
 
     private String applyConstraintToCustomer(

--- a/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/policy/service/PolicyConstraintSyncServiceImpl.java
@@ -1,6 +1,6 @@
 package com.project.domain.policy.service;
 
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -349,8 +349,8 @@ public class PolicyConstraintSyncServiceImpl implements PolicyConstraintSyncServ
         if (envelope.timestamp() == null) {
             return System.currentTimeMillis();
         }
-        // OffsetDateTime -> epoch millis로 변환해 Lua 버전 비교에 사용한다.
-        return envelope.timestamp().toInstant(ZoneOffset.UTC).toEpochMilli();
+        // timestamp를 KST 기준 epoch millis로 변환해 Lua 버전 비교에 사용
+        return envelope.timestamp().atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli();
     }
 
     private void logResult(

--- a/src/main/java/com/project/domain/policy/service/helper/PolicyEventValidator.java
+++ b/src/main/java/com/project/domain/policy/service/helper/PolicyEventValidator.java
@@ -25,9 +25,7 @@ public class PolicyEventValidator {
             return false;
         }
 
-        if (payload.familyId() == null
-                || payload.policyKey() == null
-                || payload.policyKey().isBlank()) {
+        if (payload.policyKey() == null || payload.policyKey().isBlank()) {
             log.warn(
                     "Invalid policy-updated payload. eventId={}, familyId={}, customerId={},"
                             + " policyKey={}",


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #29 
- jira: DABOM-230

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
`policy-updated` 글로벌 이벤트(`familyId=null`, `targetCustomerId=null`)를 지원하고 정책 비활성화 시 Redis 본문 키뿐 아니라 `ver:` 키까지 함께 삭제되도록 정합성을 맞추기 위함

`FamilyMember` 엔티티 전체 로딩 없이 projection 조회로 글로벌/패밀리 범위 처리 안정성을 높임

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- PolicyConstraintSyncServiceImpl
  - 글로벌 이벤트 분기 추가 (familyId=null && targetCustomerId=null)
  - 전체 대상(family_member.deleted_at is null) 순회 처리 로직 추가
  - BLOCK:APP 처리 시 일반 정책과 동일한 로그 경로(logResult) 사용
  - 삭제 시 ver: 키도 함께 삭제되도록 정리 (BLOCK:APP 경로 포함)
  - loadBlockedApps null-safe 보강
- FamilyMemberRepository
  - projection 인터페이스 추가 (FamilyMemberTargetProjection)
  - 글로벌 대상 조회 쿼리 추가 (findAllActiveTargets)
  - 가족 단위 대상 조회 projection 쿼리 추가 (findAllActiveTargetsByFamilyId)
- PolicyEventValidator
  - BLOCK:TIME/BLOCK:APP 정책 키 유효성 및 값 검증 규칙 반영

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| family/policy |  | [x] | [x] |  |  |  |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
// 글로벌 이벤트 분기
if (payload.familyId() == null && targetCustomerId == null) {
    processGlobalPolicyUpdate(eventId, policyKey, eventVersion, normalizedPolicyValue);
    return;
}

// family_member projection 기반 대상 조회
@Query(
    "select f.familyId as familyId, f.customerId as customerId "
        + "from FamilyMember f where f.deletedAt is null")
List<FamilyMemberTargetProjection> findAllActiveTargets();

// BLOCK:APP 삭제 시 앱 키 + ver 키 동시 삭제
hashOps.delete(constraintsKey, appField);
hashOps.delete(constraintsKey, buildVersionField(appField));
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 글로벌 이벤트 처리 시 즉시 fan-out 방식으로 동작합니다.
  대규모 운영에서는 배치 처리로 전환이 필요할 수 있어 관련 가이드는 별도 문서로 정리했습니다.
- FamilyMember 엔티티 컬럼 불일치 리스크를 피하기 위해 글로벌/패밀리 대상 조회를 projection으로 변경
  했습니다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
