### PR TITLE
[DABOM-361] processor-usage 월경계 정합성 처리

### DIFF
--- a/src/main/java/com/project/domain/customer/entity/Customer.java
+++ b/src/main/java/com/project/domain/customer/entity/Customer.java
@@ -26,7 +26,7 @@ public class Customer extends BaseEntity {
     @Column(nullable = false, unique = true, length = 11)
     private String phoneNumber;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 60)
     private String passwordHash;
 
     @Column(nullable = false, length = 10)

--- a/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
+++ b/src/main/java/com/project/domain/customer/entity/CustomerQuota.java
@@ -51,7 +51,7 @@ public class CustomerQuota extends BaseEntity {
     @Column(name = "is_blocked", nullable = false)
     private boolean isBlocked;
 
-    @Column(name = "block_reason")
+    @Column(name = "block_reason", length = 50)
     private String blockReason;
 
     @Builder

--- a/src/main/java/com/project/domain/family/infra/cache/FamilyCacheRepository.java
+++ b/src/main/java/com/project/domain/family/infra/cache/FamilyCacheRepository.java
@@ -1,5 +1,6 @@
 package com.project.domain.family.infra.cache;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import com.project.domain.family.entity.Family;
 import com.project.domain.family.infra.cache.dto.FamilyCacheDto;
+import com.project.global.common.TimeConstants;
 import com.project.global.util.RedisKeyGenerator;
 
 import lombok.RequiredArgsConstructor;
@@ -46,7 +48,10 @@ public class FamilyCacheRepository {
     }
 
     public Optional<Long> findCustomerMonthlyUsageBytes(Long familyId, Long customerId) {
-        String key = redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(familyId, customerId);
+        LocalDate currentMonth = LocalDate.now(TimeConstants.ASIA_SEOUL).withDayOfMonth(1);
+        String key =
+                redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(
+                        familyId, customerId, currentMonth);
         return findLongValue(key);
     }
 

--- a/src/main/java/com/project/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/project/domain/family/repository/FamilyRepository.java
@@ -1,5 +1,7 @@
 package com.project.domain.family.repository;
 
+import java.time.LocalDate;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,9 +14,17 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
     @Modifying
     @Query(
             "update Family f "
-                    + "set f.usedBytes = f.usedBytes + :bytesUsed, "
+                    + "set f.currentMonth = case when f.currentMonth < :eventMonth then"
+                    + " :eventMonth else f.currentMonth end, "
+                    + "f.usedBytes = case "
+                    + "when f.currentMonth < :eventMonth then :bytesUsed "
+                    + "when f.currentMonth = :eventMonth then f.usedBytes + :bytesUsed "
+                    + "else f.usedBytes end, "
                     + "f.updatedAt = CURRENT_TIMESTAMP "
                     + "where f.id = :familyId "
                     + "and f.deletedAt is null")
-    int updateUsedBytes(@Param("familyId") Long familyId, @Param("bytesUsed") Long bytesUsed);
+    int updateUsedBytesByEventMonth(
+            @Param("familyId") Long familyId,
+            @Param("eventMonth") LocalDate eventMonth,
+            @Param("bytesUsed") Long bytesUsed);
 }

--- a/src/main/java/com/project/domain/usage/service/UsagePersistServiceImpl.java
+++ b/src/main/java/com/project/domain/usage/service/UsagePersistServiceImpl.java
@@ -82,7 +82,7 @@ public class UsagePersistServiceImpl implements UsagePersistService {
         // 4) 허용 이벤트의 월 누적 반영
         customerQuotaWriter.persistAllowedQuota(payload, currentMonth, eventId, originEventId);
         familyUsageWriter.updateFamilyUsedBytes(
-                payload.familyId(), payload.bytesUsed(), eventId, originEventId);
+                payload.familyId(), currentMonth, payload.bytesUsed(), eventId, originEventId);
     }
 
     private boolean isValidFamilyMember(Long familyId, Long customerId) {

--- a/src/main/java/com/project/domain/usage/service/UsageSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.domain.usage.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -47,12 +48,15 @@ public class UsageSyncServiceImpl implements UsageSyncService {
         Long familyId = payload.familyId();
         Long customerId = payload.customerId();
         long usageBytes = payload.bytesUsed();
+        LocalDateTime resolvedEventDateTime = resolveEventDateTime(eventTime);
+        LocalDate eventMonth = resolvedEventDateTime.toLocalDate().withDayOfMonth(1);
 
         // Redis Key 생성
         String infoKey = redisKeyGenerator.generateFamilyInfoKey(familyId);
         String remainingKey = redisKeyGenerator.generateFamilyRemainingKey(familyId);
         String monthlyKey =
-                redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(familyId, customerId);
+                redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(
+                        familyId, customerId, eventMonth);
         String constraintsKey =
                 redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId);
         String alertsKey = redisKeyGenerator.generateFamilyAlertsKey(familyId);
@@ -63,7 +67,8 @@ public class UsageSyncServiceImpl implements UsageSyncService {
         boolean familyRemainingRedisWarmup =
                 usageRedisWarmupHelper.ensureRemainingBytesCached(familyId, remainingKey);
         boolean customerMonthlyUsageRedisWarmup =
-                usageRedisWarmupHelper.ensureCustomerUsageCached(familyId, customerId, monthlyKey);
+                usageRedisWarmupHelper.ensureCustomerUsageCached(
+                        familyId, customerId, monthlyKey, eventMonth);
         policyConstraintWarmupHelper.warmupIfMissing(familyId, customerId);
 
         if (!familyInfoRedisWarmup
@@ -73,7 +78,7 @@ public class UsageSyncServiceImpl implements UsageSyncService {
             return;
         }
 
-        String currentHhmm = resolveCurrentHhmm(eventTime);
+        String currentHhmm = resolvedEventDateTime.format(HHMM_FORMATTER);
 
         // Lua Script 실행 + 결과 파싱
         UsageUpdateResult parsed =
@@ -98,16 +103,16 @@ public class UsageSyncServiceImpl implements UsageSyncService {
                 new UsageEventPublisher.UsageEventContext(eventId, eventTime, payload, parsed));
     }
 
-    private String resolveCurrentHhmm(String eventTime) {
+    private LocalDateTime resolveEventDateTime(String eventTime) {
         // producer가 전달한 eventTime이 있으면 우선 사용한다.
         if (eventTime != null && !eventTime.isBlank()) {
             try {
-                return LocalDateTime.parse(eventTime).format(HHMM_FORMATTER);
+                return LocalDateTime.parse(eventTime);
             } catch (DateTimeParseException ignored) {
                 log.debug("Failed to parse eventTime: {}", logSanitizer.sanitize(eventTime));
             }
         }
         // eventTime이 없거나 파싱 실패 시 서버 현재 시각으로 보정한다.
-        return LocalDateTime.now(TimeConstants.ASIA_SEOUL).format(HHMM_FORMATTER);
+        return LocalDateTime.now(TimeConstants.ASIA_SEOUL);
     }
 }

--- a/src/main/java/com/project/domain/usage/service/helper/FamilyUsageWriter.java
+++ b/src/main/java/com/project/domain/usage/service/helper/FamilyUsageWriter.java
@@ -1,5 +1,7 @@
 package com.project.domain.usage.service.helper;
 
+import java.time.LocalDate;
+
 import org.springframework.stereotype.Service;
 
 import com.project.domain.family.repository.FamilyRepository;
@@ -18,18 +20,24 @@ public class FamilyUsageWriter {
 
     // 허용 이벤트의 bytesUsed를 family.used_bytes에 누적 반영한다.
     public void updateFamilyUsedBytes(
-            Long familyId, Long bytesUsed, String eventId, String originEventId) {
-        int updatedRows = familyRepository.updateUsedBytes(familyId, bytesUsed);
+            Long familyId,
+            LocalDate eventMonth,
+            Long bytesUsed,
+            String eventId,
+            String originEventId) {
+        int updatedRows =
+                familyRepository.updateUsedBytesByEventMonth(familyId, eventMonth, bytesUsed);
         if (updatedRows > 0) {
             return;
         }
 
         log.warn(
                 "Failed to update family.used_bytes. eventId={}, originEventId={}, familyId={},"
-                        + " bytesUsed={}",
+                        + " eventMonth={}, bytesUsed={}",
                 logSanitizer.sanitize(eventId),
                 logSanitizer.sanitize(originEventId),
                 familyId,
+                eventMonth,
                 bytesUsed);
         throw new IllegalStateException("Failed to update family used bytes");
     }

--- a/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
+++ b/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
@@ -2,9 +2,14 @@ package com.project.domain.usage.service.helper;
 
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.stereotype.Service;
 
 import com.project.domain.customer.entity.CustomerQuota;
@@ -13,6 +18,7 @@ import com.project.domain.family.entity.Family;
 import com.project.domain.family.repository.FamilyRepository;
 import com.project.domain.usage.infra.cache.dto.FamilyInfoRedisHash;
 import com.project.domain.usage.service.dto.FamilyInfo;
+import com.project.global.common.TimeConstants;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -129,20 +135,28 @@ public class UsageRedisWarmupHelper {
                                     familyId, customerId, currentMonth)
                             .orElse(null);
 
-            if (quota == null) {
-                log.warn(
-                        "CustomerQuota not found. familyId={}, customerId={}, currentMonth={}",
-                        familyId,
-                        customerId,
-                        currentMonth);
-                return false;
-            }
+            long usedBytes = (quota == null) ? 0L : Math.max(0L, quota.getMonthlyUsedBytes());
+            long nextMonthStartEpochSecond =
+                    currentMonth
+                            .plusMonths(1)
+                            .atStartOfDay(TimeConstants.ASIA_SEOUL)
+                            .toEpochSecond();
 
-            long usedBytes = Math.max(0L, quota.getMonthlyUsedBytes());
-
-            // Redis에 생성
+            // 키가 없어도 월초 첫 트래픽을 안전하게 처리하도록 0으로 시드하고 만료를 설정함
             Boolean written =
-                    stringRedisTemplate.opsForValue().setIfAbsent(key, String.valueOf(usedBytes));
+                    stringRedisTemplate.execute(
+                            (RedisCallback<Boolean>)
+                                    connection -> {
+                                        StringRedisConnection redisConnection =
+                                                (StringRedisConnection) connection;
+                                        return redisConnection.set(
+                                                key,
+                                                String.valueOf(usedBytes),
+                                                Expiration.unixTimestamp(
+                                                        nextMonthStartEpochSecond,
+                                                        TimeUnit.SECONDS),
+                                                SetOption.UPSERT);
+                                    });
 
             if (Boolean.TRUE.equals(written)) {
                 return true;

--- a/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
+++ b/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
@@ -129,10 +129,7 @@ public class UsageRedisWarmupHelper {
 
             long usedBytes = (quota == null) ? 0L : Math.max(0L, quota.getMonthlyUsedBytes());
             long nextMonthStartEpochSecond =
-                    eventMonth
-                            .plusMonths(1)
-                            .atStartOfDay(TimeConstants.ASIA_SEOUL)
-                            .toEpochSecond();
+                    eventMonth.plusMonths(1).atStartOfDay(TimeConstants.ASIA_SEOUL).toEpochSecond();
 
             // 키가 없어도 월초 첫 트래픽을 안전하게 처리하도록 0으로 시드하고 만료를 설정함
             Boolean written =

--- a/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
+++ b/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
@@ -111,7 +111,8 @@ public class UsageRedisWarmupHelper {
         }
     }
 
-    public boolean ensureCustomerUsageCached(long familyId, long customerId, String key) {
+    public boolean ensureCustomerUsageCached(
+            long familyId, long customerId, String key, LocalDate eventMonth) {
         try {
             // Redis에 이미 존재하면 성공
             Boolean exists = stringRedisTemplate.hasKey(key);
@@ -119,25 +120,16 @@ public class UsageRedisWarmupHelper {
                 return true;
             }
 
-            // Family 조회 (currentMonth 확보용)
-            Family family = familyRepository.findById(familyId).orElse(null);
-            if (family == null) {
-                log.warn("Family not found. familyId={}", familyId);
-                return false;
-            }
-
-            LocalDate currentMonth = family.getCurrentMonth();
-
             // CustomerQuota 조회
             CustomerQuota quota =
                     customerQuotaRepository
                             .findActiveByFamilyIdAndCustomerIdAndCurrentMonth(
-                                    familyId, customerId, currentMonth)
+                                    familyId, customerId, eventMonth)
                             .orElse(null);
 
             long usedBytes = (quota == null) ? 0L : Math.max(0L, quota.getMonthlyUsedBytes());
             long nextMonthStartEpochSecond =
-                    currentMonth
+                    eventMonth
                             .plusMonths(1)
                             .atStartOfDay(TimeConstants.ASIA_SEOUL)
                             .toEpochSecond();
@@ -168,16 +160,20 @@ public class UsageRedisWarmupHelper {
 
         } catch (DataAccessException e) {
             log.error(
-                    "Data access error during usage cache warm-up. familyId={}, customerId={}",
+                    "Data access error during usage cache warm-up. familyId={}, customerId={},"
+                            + " eventMonth={}",
                     familyId,
                     customerId,
+                    eventMonth,
                     e);
             return false;
         } catch (RuntimeException e) {
             log.error(
-                    "Unexpected error during usage cache warm-up. familyId={}, customerId={}",
+                    "Unexpected error during usage cache warm-up. familyId={}, customerId={},"
+                            + " eventMonth={}",
                     familyId,
                     customerId,
+                    eventMonth,
                     e);
             return false;
         }

--- a/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
+++ b/src/main/java/com/project/domain/usage/service/helper/UsageRedisWarmupHelper.java
@@ -155,7 +155,7 @@ public class UsageRedisWarmupHelper {
                                                 Expiration.unixTimestamp(
                                                         nextMonthStartEpochSecond,
                                                         TimeUnit.SECONDS),
-                                                SetOption.UPSERT);
+                                                SetOption.SET_IF_ABSENT);
                                     });
 
             if (Boolean.TRUE.equals(written)) {

--- a/src/main/java/com/project/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/project/global/util/RedisKeyGenerator.java
@@ -1,5 +1,8 @@
 package com.project.global.util;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.springframework.stereotype.Component;
 
 @Component
@@ -8,6 +11,8 @@ public class RedisKeyGenerator {
     private static final String KEY_SEPARATOR = ":";
     private static final String FAMILY_KEY_PREFIX = "family";
     private static final String POLICY_EVENT_DEDUP_KEY_PREFIX = "event:dedup:policy";
+    private static final DateTimeFormatter MONTH_SUFFIX_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMM");
 
     public String generateFamilyAlertsKey(Long familyId) {
         return FAMILY_KEY_PREFIX
@@ -27,7 +32,8 @@ public class RedisKeyGenerator {
         return FAMILY_KEY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + "remaining";
     }
 
-    public String generateFamilyCustomerMonthlyUsageKey(Long familyId, Long customerId) {
+    public String generateFamilyCustomerMonthlyUsageKey(
+            Long familyId, Long customerId, LocalDate eventMonth) {
         return FAMILY_KEY_PREFIX
                 + KEY_SEPARATOR
                 + familyId
@@ -38,7 +44,9 @@ public class RedisKeyGenerator {
                 + KEY_SEPARATOR
                 + "usage"
                 + KEY_SEPARATOR
-                + "monthly";
+                + "monthly"
+                + KEY_SEPARATOR
+                + eventMonth.format(MONTH_SUFFIX_FORMATTER);
     }
 
     public String generateFamilyCustomerConstraintsKey(Long familyId, Long customerId) {

--- a/src/main/resources/lua/usage_update.lua
+++ b/src/main/resources/lua/usage_update.lua
@@ -1,6 +1,6 @@
 -- KEYS[1]: family:{fid}:info
 -- KEYS[2]: family:{fid}:remaining
--- KEYS[3]: family:{fid}:customer:{uid}:usage:monthly
+-- KEYS[3]: family:{fid}:customer:{uid}:usage:monthly:{yyyyMM}
 -- KEYS[4]: family:{fid}:customer:{uid}:constraints
 -- KEYS[5]: family:{fid}:alert:THRESHOLD (prefix)
 -- ARGV[1]: usageBytes

--- a/src/test/java/com/project/domain/usage/service/UsagePersistServiceImplTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsagePersistServiceImplTest.java
@@ -73,8 +73,7 @@ class UsagePersistServiceImplTest {
                 .persistAllowedQuota(payload, eventMonth, "evt_1", "origin_1");
         verify(familyUsageWriter, times(1))
                 .updateFamilyUsedBytes(100L, eventMonth, 2048L, "evt_1", "origin_1");
-        verify(customerQuotaWriter, never())
-                .persistBlockedQuota(any(), any(), any(), any(), any());
+        verify(customerQuotaWriter, never()).persistBlockedQuota(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -82,13 +81,7 @@ class UsagePersistServiceImplTest {
     void persist_BlockedEvent_OnlyPersistsBlockState() {
         UsagePersistPayload payload =
                 new UsagePersistPayload(
-                        "origin_2",
-                        200L,
-                        2L,
-                        1024L,
-                        "app",
-                        "TIME_BLOCK",
-                        "2026-03-20T10:20:30");
+                        "origin_2", 200L, 2L, 1024L, "app", "TIME_BLOCK", "2026-03-20T10:20:30");
         EventEnvelope<UsagePersistPayload> envelope =
                 new EventEnvelope<>("evt_2", "USAGE_PERSIST", null, LocalDateTime.now(), payload);
         LocalDate eventMonth = LocalDate.of(2026, 3, 1);

--- a/src/test/java/com/project/domain/usage/service/UsagePersistServiceImplTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsagePersistServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.project.domain.usage.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.usage.service.helper.CustomerQuotaWriter;
+import com.project.domain.usage.service.helper.FamilyUsageWriter;
+import com.project.domain.usage.service.helper.UsagePersistEventValidator;
+import com.project.domain.usage.service.helper.UsageRecordWriter;
+import com.project.global.event.dto.EventEnvelope;
+import com.project.global.event.dto.usage.UsagePersistPayload;
+import com.project.global.util.LogSanitizer;
+
+@ExtendWith(MockitoExtension.class)
+class UsagePersistServiceImplTest {
+
+    @InjectMocks private UsagePersistServiceImpl usagePersistService;
+
+    @Mock private FamilyMemberRepository familyMemberRepository;
+    @Mock private UsagePersistEventValidator usagePersistEventValidator;
+    @Mock private UsageRecordWriter usageRecordWriter;
+    @Mock private CustomerQuotaWriter customerQuotaWriter;
+    @Mock private FamilyUsageWriter familyUsageWriter;
+    @Mock private LogSanitizer logSanitizer;
+
+    @BeforeEach
+    void setUp() {
+        lenient()
+                .when(logSanitizer.sanitize(nullable(String.class)))
+                .thenAnswer(
+                        invocation -> {
+                            String raw = invocation.getArgument(0);
+                            return raw == null ? "null" : raw;
+                        });
+    }
+
+    @Test
+    @DisplayName("허용 이벤트면 eventMonth 기준으로 quota와 family를 함께 갱신한다")
+    void persist_AllowedEvent_UpdatesQuotaAndFamilyByEventMonth() {
+        UsagePersistPayload payload =
+                new UsagePersistPayload(
+                        "origin_1", 100L, 1L, 2048L, "app", "ALLOWED", "2026-03-15T01:02:03");
+        EventEnvelope<UsagePersistPayload> envelope =
+                new EventEnvelope<>("evt_1", "USAGE_PERSIST", null, LocalDateTime.now(), payload);
+        LocalDate eventMonth = LocalDate.of(2026, 3, 1);
+
+        given(usagePersistEventValidator.isValidPayload(payload, "evt_1", "recordKey"))
+                .willReturn(true);
+        given(familyMemberRepository.existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(100L, 1L))
+                .willReturn(true);
+        given(usageRecordWriter.persistUsageRecord(payload, "evt_1", "origin_1")).willReturn(true);
+
+        usagePersistService.persist(envelope, "recordKey");
+
+        verify(customerQuotaWriter, times(1))
+                .persistAllowedQuota(payload, eventMonth, "evt_1", "origin_1");
+        verify(familyUsageWriter, times(1))
+                .updateFamilyUsedBytes(100L, eventMonth, 2048L, "evt_1", "origin_1");
+        verify(customerQuotaWriter, never())
+                .persistBlockedQuota(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("차단 이벤트면 usage_record와 family 누적 없이 차단 상태만 반영한다")
+    void persist_BlockedEvent_OnlyPersistsBlockState() {
+        UsagePersistPayload payload =
+                new UsagePersistPayload(
+                        "origin_2",
+                        200L,
+                        2L,
+                        1024L,
+                        "app",
+                        "TIME_BLOCK",
+                        "2026-03-20T10:20:30");
+        EventEnvelope<UsagePersistPayload> envelope =
+                new EventEnvelope<>("evt_2", "USAGE_PERSIST", null, LocalDateTime.now(), payload);
+        LocalDate eventMonth = LocalDate.of(2026, 3, 1);
+
+        given(usagePersistEventValidator.isValidPayload(payload, "evt_2", "recordKey"))
+                .willReturn(true);
+        given(familyMemberRepository.existsByFamilyIdAndCustomerIdAndDeletedAtIsNull(200L, 2L))
+                .willReturn(true);
+
+        usagePersistService.persist(envelope, "recordKey");
+
+        verify(customerQuotaWriter, times(1))
+                .persistBlockedQuota(payload, eventMonth, "evt_2", "origin_2", "TIME_BLOCK");
+        verify(usageRecordWriter, never()).persistUsageRecord(any(), any(), any());
+        verify(customerQuotaWriter, never()).persistAllowedQuota(any(), any(), any(), any());
+        verify(familyUsageWriter, never()).updateFamilyUsedBytes(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/com/project/domain/usage/service/UsageSyncServiceImplTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsageSyncServiceImplTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -58,10 +58,11 @@ class UsageSyncServiceImplTest {
     @DisplayName("정상 흐름이면 Lua 실행 후 이벤트 발행기로 위임한다")
     void syncUsage_SuccessFlow() {
         String eventId = "evt_1";
-        String eventTime = LocalDateTime.now().toString();
+        String eventTime = "2026-03-04T12:34:56";
+        LocalDate eventMonth = LocalDate.of(2026, 3, 1);
         UsagePayload payload = new UsagePayload(100L, 1L, "appId", 1024L, Map.of());
 
-        stubCommon(100L, 1L);
+        stubCommon(100L, 1L, eventMonth);
 
         UsageUpdateResult luaResult =
                 new UsageUpdateResult(5000L, 5000L, "NORMAL", 1000L, 0.1, 10000L);
@@ -81,7 +82,7 @@ class UsageSyncServiceImplTest {
         assertEquals("constraintsKey", command.constraintsKey());
         assertEquals("alertsKey", command.alertsKey());
         assertEquals(1024L, command.usageBytes());
-        assertEquals(4, command.currentHhmm().length());
+        assertEquals("1234", command.currentHhmm());
 
         verify(usageEventPublisher, times(1))
                 .publish(any(UsageEventPublisher.UsageEventContext.class));
@@ -91,12 +92,14 @@ class UsageSyncServiceImplTest {
     @DisplayName("Warmup 실패 시 Lua 실행과 이벤트 발행을 하지 않는다")
     void syncUsage_WarmupFailed() {
         String eventId = "evt_2";
+        String eventTime = "2026-03-04T10:10:10";
+        LocalDate eventMonth = LocalDate.of(2026, 3, 1);
         UsagePayload payload = new UsagePayload(100L, 1L, "appId", 1024L, Map.of());
 
         given(redisKeyGenerator.generateFamilyInfoKey(100L)).willReturn("family:100:info");
         given(redisKeyGenerator.generateFamilyRemainingKey(100L))
                 .willReturn("family:100:remaining");
-        given(redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(100L, 1L))
+        given(redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(100L, 1L, eventMonth))
                 .willReturn("monthlyKey");
         given(redisKeyGenerator.generateFamilyCustomerConstraintsKey(100L, 1L))
                 .willReturn("constraintsKey");
@@ -106,21 +109,23 @@ class UsageSyncServiceImplTest {
                 .willReturn(false);
         given(usageRedisWarmupHelper.ensureRemainingBytesCached(100L, "family:100:remaining"))
                 .willReturn(true);
-        given(usageRedisWarmupHelper.ensureCustomerUsageCached(100L, 1L, "monthlyKey"))
+        given(usageRedisWarmupHelper.ensureCustomerUsageCached(100L, 1L, "monthlyKey", eventMonth))
                 .willReturn(true);
 
-        usageSyncServiceImpl.syncUsage(eventId, LocalDateTime.now().toString(), payload);
+        usageSyncServiceImpl.syncUsage(eventId, eventTime, payload);
 
         verify(usageLuaExecutor, never()).execute(any(), any());
         verify(usageEventPublisher, never()).publish(any());
     }
 
-    private void stubCommon(long familyId, long customerId) {
+    private void stubCommon(long familyId, long customerId, LocalDate eventMonth) {
         given(redisKeyGenerator.generateFamilyInfoKey(familyId))
                 .willReturn("family:" + familyId + ":info");
         given(redisKeyGenerator.generateFamilyRemainingKey(familyId))
                 .willReturn("family:" + familyId + ":remaining");
-        given(redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(familyId, customerId))
+        given(
+                        redisKeyGenerator.generateFamilyCustomerMonthlyUsageKey(
+                                familyId, customerId, eventMonth))
                 .willReturn("monthlyKey");
         given(redisKeyGenerator.generateFamilyCustomerConstraintsKey(familyId, customerId))
                 .willReturn("constraintsKey");
@@ -133,7 +138,9 @@ class UsageSyncServiceImplTest {
                         usageRedisWarmupHelper.ensureRemainingBytesCached(
                                 familyId, "family:" + familyId + ":remaining"))
                 .willReturn(true);
-        given(usageRedisWarmupHelper.ensureCustomerUsageCached(familyId, customerId, "monthlyKey"))
+        given(
+                        usageRedisWarmupHelper.ensureCustomerUsageCached(
+                                familyId, customerId, "monthlyKey", eventMonth))
                 .willReturn(true);
     }
 }

--- a/src/test/java/com/project/domain/usage/service/helper/FamilyUsageWriterTest.java
+++ b/src/test/java/com/project/domain/usage/service/helper/FamilyUsageWriterTest.java
@@ -43,8 +43,7 @@ class FamilyUsageWriterTest {
     @DisplayName("family 월경계 업데이트가 성공하면 예외 없이 종료한다")
     void updateFamilyUsedBytes_Success() {
         LocalDate eventMonth = LocalDate.of(2026, 3, 1);
-        given(familyRepository.updateUsedBytesByEventMonth(100L, eventMonth, 1024L))
-                .willReturn(1);
+        given(familyRepository.updateUsedBytesByEventMonth(100L, eventMonth, 1024L)).willReturn(1);
 
         familyUsageWriter.updateFamilyUsedBytes(100L, eventMonth, 1024L, "evt_1", "origin_1");
 
@@ -55,8 +54,7 @@ class FamilyUsageWriterTest {
     @DisplayName("family row 업데이트에 실패하면 예외를 던진다")
     void updateFamilyUsedBytes_Fail_ThrowsException() {
         LocalDate eventMonth = LocalDate.of(2026, 3, 1);
-        given(familyRepository.updateUsedBytesByEventMonth(100L, eventMonth, 1024L))
-                .willReturn(0);
+        given(familyRepository.updateUsedBytesByEventMonth(100L, eventMonth, 1024L)).willReturn(0);
 
         assertThrows(
                 IllegalStateException.class,

--- a/src/test/java/com/project/domain/usage/service/helper/FamilyUsageWriterTest.java
+++ b/src/test/java/com/project/domain/usage/service/helper/FamilyUsageWriterTest.java
@@ -1,0 +1,67 @@
+package com.project.domain.usage.service.helper;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.project.domain.family.repository.FamilyRepository;
+import com.project.global.util.LogSanitizer;
+
+@ExtendWith(MockitoExtension.class)
+class FamilyUsageWriterTest {
+
+    @InjectMocks private FamilyUsageWriter familyUsageWriter;
+
+    @Mock private FamilyRepository familyRepository;
+    @Mock private LogSanitizer logSanitizer;
+
+    @BeforeEach
+    void setUp() {
+        lenient()
+                .when(logSanitizer.sanitize(nullable(String.class)))
+                .thenAnswer(
+                        invocation -> {
+                            String raw = invocation.getArgument(0);
+                            return raw == null ? "null" : raw;
+                        });
+    }
+
+    @Test
+    @DisplayName("family 월경계 업데이트가 성공하면 예외 없이 종료한다")
+    void updateFamilyUsedBytes_Success() {
+        LocalDate eventMonth = LocalDate.of(2026, 3, 1);
+        given(familyRepository.updateUsedBytesByEventMonth(100L, eventMonth, 1024L))
+                .willReturn(1);
+
+        familyUsageWriter.updateFamilyUsedBytes(100L, eventMonth, 1024L, "evt_1", "origin_1");
+
+        verify(familyRepository, times(1)).updateUsedBytesByEventMonth(100L, eventMonth, 1024L);
+    }
+
+    @Test
+    @DisplayName("family row 업데이트에 실패하면 예외를 던진다")
+    void updateFamilyUsedBytes_Fail_ThrowsException() {
+        LocalDate eventMonth = LocalDate.of(2026, 3, 1);
+        given(familyRepository.updateUsedBytesByEventMonth(100L, eventMonth, 1024L))
+                .willReturn(0);
+
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        familyUsageWriter.updateFamilyUsedBytes(
+                                100L, eventMonth, 1024L, "evt_1", "origin_1"));
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #39 
- jira: DABOM-361

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
월경계 시점(특히 00:00~00:01) 이벤트 처리 시 `family.used_bytes`/`family.current_month` 정합성을 보장하고,
Redis 개인 월사용량 키를 월 식별 가능한 `usage:monthly:{yyyyMM}` 구조로 전환하기 위함

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- Redis 개인 월사용량 키 규칙을 `family:{fid}:customer:{uid}:usage:monthly:{yyyyMM}`로 변경
- `UsageSyncServiceImpl`에서 `eventTime` 기반 `eventMonth` 계산 후 월 suffix 키 생성
- `UsageRedisWarmupHelper`에서 `eventMonth` 기준 quota 조회 및 EXAT 만료 시각 계산
- `FamilyRepository`에 월경계 원자 갱신 쿼리 적용
  - `current_month < eventMonth`: `current_month=eventMonth`, `used_bytes=bytesUsed`
  - `current_month = eventMonth`: `used_bytes += bytesUsed`
- `UsagePersistServiceImpl` → `FamilyUsageWriter` 호출 시 `eventMonth` 전달
- 회귀 테스트 추가/수정
  - `UsageSyncServiceImplTest` 수정
  - `UsagePersistServiceImplTest` 추가
  - `FamilyUsageWriterTest` 추가

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| usage  |            |    [x]  |            |        |  [x]  |        |
| family |            |    [x]  |    [x]     |        |  [x]  |        |
| common |            |         |            |        |       |   [x]  |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
long usedBytes = (quota == null) ? 0L : Math.max(0L, quota.getMonthlyUsedBytes());
long nextMonthStartEpochSecond =
        currentMonth
                .plusMonths(1)
                .atStartOfDay(TimeConstants.ASIA_SEOUL)
                .toEpochSecond();

// 키가 없어도 월초 첫 트래픽을 안전하게 처리하도록 0으로 시드하고 만료를 설정함
Boolean written =
        stringRedisTemplate.execute(
                (RedisCallback<Boolean>)
                        connection -> {
                            StringRedisConnection redisConnection =
                                    (StringRedisConnection) connection;
                            return redisConnection.set(
                                    key,
                                    String.valueOf(usedBytes),
                                    Expiration.unixTimestamp(
                                            nextMonthStartEpochSecond,
                                            TimeUnit.SECONDS),
                                    SetOption.UPSERT);
                        });
```
```java
// family 월경계 원자 갱신 쿼리
@Modifying
@Query(
    "update Family f "
  + "set f.currentMonth = case when f.currentMonth < :eventMonth then :eventMonth else f.currentMonth end, "
  + "f.usedBytes = case "
  + "when f.currentMonth < :eventMonth then :bytesUsed "
  + "when f.currentMonth = :eventMonth then f.usedBytes + :bytesUsed "
  + "else f.usedBytes end, "
  + "f.updatedAt = CURRENT_TIMESTAMP "
  + "where f.id = :familyId and f.deletedAt is null")
int updateUsedBytesByEventMonth(Long familyId, LocalDate eventMonth, Long bytesUsed);
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 여기에서 TTL을 설정하는 이유는 월초 배치가 실패할 경우를 대비해서 우선 적용했습니다

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
