### PR TITLE
[DABOM-409] 가족 데이터량이 0MB가 되었을 때 차단되는 현상 수정

### DIFF
--- a/src/main/resources/lua/usage_update.lua
+++ b/src/main/resources/lua/usage_update.lua
@@ -21,7 +21,9 @@ local function getResult(status, currentMonthlyUsed, duplicate)
     local currentRemaining = tonumber(redis.call('GET', KEYS[2]) or totalLimit)
     local totalUsed = totalLimit - currentRemaining
     local userRatio = 0
-    if totalLimit > 0 then userRatio = currentMonthlyUsed / totalLimit end
+    if totalLimit > 0 then
+        userRatio = currentMonthlyUsed / totalLimit
+    end
 
     return {
         totalUsed,
@@ -34,16 +36,15 @@ local function getResult(status, currentMonthlyUsed, duplicate)
     }
 end
 
--- 1. usage-event dedup 검사
+-- 1) 동일 eventId 재처리 방지
 if dedupTtlSeconds > 0 then
     local firstSeen = redis.call('SET', KEYS[6], '1', 'NX', 'EX', dedupTtlSeconds)
     if not firstSeen then
-        -- duplicate면 Java에서 상세 수치를 사용하지 않으므로 고정값만 반환한다.
-        return {0, 0, "DUPLICATE", 0, 0, -1, 1}
+        return {0, 0, 'DUPLICATE', 0, 0, -1, 1}
     end
 end
 
--- 2. 고객 정책 제약 로딩
+-- 2) 고객별 제약 조회
 local constraintsArray = redis.call('HGETALL', KEYS[4])
 local constraints = {}
 for i = 1, #constraintsArray, 2 do
@@ -51,17 +52,19 @@ for i = 1, #constraintsArray, 2 do
 end
 
 local monthlyLimitStr = constraints['LIMIT:DATA:MONTHLY']
-if monthlyLimitStr then monthlyLimit = tonumber(monthlyLimitStr) end
+if monthlyLimitStr then
+    monthlyLimit = tonumber(monthlyLimitStr)
+end
 
 local currentMonthly = tonumber(redis.call('GET', KEYS[3]) or '0')
 
--- 3. 차단/제한 조건 검사
-if constraints['BLOCK:ACCESS'] == "1" then
-    return getResult("MANUAL", currentMonthly, false)
+-- 3) 차단/제한 조건 확인
+if constraints['BLOCK:ACCESS'] == '1' then
+    return getResult('MANUAL', currentMonthly, false)
 end
 
-if appId ~= '' and constraints['BLOCK:APP:' .. appId] == "1" then
-    return getResult("APP_BLOCK", currentMonthly, false)
+if appId ~= '' and constraints['BLOCK:APP:' .. appId] == '1' then
+    return getResult('APP_BLOCK', currentMonthly, false)
 end
 
 local blockStart = nil
@@ -69,7 +72,7 @@ local blockEnd = nil
 
 local blockTimeRange = constraints['BLOCK:TIME']
 if blockTimeRange then
-    local dashPos = string.find(blockTimeRange, "-", 1, true)
+    local dashPos = string.find(blockTimeRange, '-', 1, true)
     if dashPos then
         local startStr = string.sub(blockTimeRange, 1, dashPos - 1)
         local endStr = string.sub(blockTimeRange, dashPos + 1)
@@ -81,20 +84,20 @@ end
 if blockStart and blockEnd then
     if blockStart < blockEnd then
         if currentHHmm >= blockStart and currentHHmm < blockEnd then
-            return getResult("TIME_BLOCK", currentMonthly, false)
+            return getResult('TIME_BLOCK', currentMonthly, false)
         end
     elseif blockStart > blockEnd then
         if currentHHmm >= blockStart or currentHHmm < blockEnd then
-            return getResult("TIME_BLOCK", currentMonthly, false)
+            return getResult('TIME_BLOCK', currentMonthly, false)
         end
     else
-        return getResult("TIME_BLOCK", currentMonthly, false)
+        return getResult('TIME_BLOCK', currentMonthly, false)
     end
 end
 
 if monthlyLimit ~= -1 then
     if (currentMonthly + usageBytes) > monthlyLimit then
-        return getResult("MONTHLY_LIMIT_EXCEEDED", currentMonthly, false)
+        return getResult('MONTHLY_LIMIT_EXCEEDED', currentMonthly, false)
     end
 end
 
@@ -105,53 +108,51 @@ if currentRemaining == nil then
 end
 
 if currentRemaining < usageBytes then
-    return getResult("FAMILY_QUOTA_EXCEEDED", currentMonthly, false)
+    return getResult('FAMILY_QUOTA_EXCEEDED', currentMonthly, false)
 end
 
--- 4. 사용량 반영
+-- 4) 사용량 반영
 local newRemaining = redis.call('DECRBY', KEYS[2], usageBytes)
 local newMonthly = redis.call('INCRBY', KEYS[3], usageBytes)
 
--- 5. 경고 상태 계산
+-- 5) 후속 상태 계산
 local limitStr = redis.call('HGET', KEYS[1], 'totalQuota')
 local totalLimit = tonumber(limitStr or '0')
-local status = "NORMAL"
+local status = 'NORMAL'
+local ratio = 0
 
-if newRemaining <= 0 then
-    status = "FAMILY_QUOTA_EXCEEDED"
-else
-    local ratio = 0
-    if totalLimit > 0 then
-        ratio = newRemaining / totalLimit
-    end
+if totalLimit > 0 then
+    ratio = newRemaining / totalLimit
+end
 
-    local alertLevel = nil
-    if ratio < 0.1 then
-        alertLevel = "10"
-        status = "WARNING_10"
-    elseif ratio < 0.3 then
-        alertLevel = "30"
-        status = "WARNING_30"
-    elseif ratio < 0.5 then
-        alertLevel = "50"
-        status = "WARNING_50"
-    end
+local alertLevel = nil
+if ratio < 0.1 then
+    alertLevel = '10'
+    status = 'WARNING_10'
+elseif ratio < 0.3 then
+    alertLevel = '30'
+    status = 'WARNING_30'
+elseif ratio < 0.5 then
+    alertLevel = '50'
+    status = 'WARNING_50'
+end
 
-    -- 같은 임계치 알림은 한 번만 발행되게 보호
-    if alertLevel then
-        local alertKey = KEYS[5] .. ":" .. alertLevel
-        local isSent = redis.call('EXISTS', alertKey)
+-- 같은 임계치 알림은 한 번만 발행
+if alertLevel then
+    local alertKey = KEYS[5] .. ':' .. alertLevel
+    local isSent = redis.call('EXISTS', alertKey)
 
-        if isSent == 1 then
-            status = "NORMAL"
-        else
-            redis.call('SET', alertKey, "PUBLISHED")
-        end
+    if isSent == 1 then
+        status = 'NORMAL'
+    else
+        redis.call('SET', alertKey, 'PUBLISHED')
     end
 end
 
 local totalUsed = totalLimit - newRemaining
 local userRatio = 0
-if totalLimit > 0 then userRatio = newMonthly / totalLimit end
+if totalLimit > 0 then
+    userRatio = newMonthly / totalLimit
+end
 
 return {totalUsed, newRemaining, status, newMonthly, userRatio, monthlyLimit, 0}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #50 
- jira: DABOM-209

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
가족 공유 데이터와 동일한 기준으로, 개인 월 사용량도 한도에 정확히 도달하는 마지막 사용 이벤트는 허용하고 그 다음 이벤트부터 차단되도록 정책을 맞추기 위함

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->
- usage_update.lua의 사용량 판정 로직 정리
- 가족 잔여량이 정확히 0이 되는 마지막 이벤트를 차단 상태가 아닌 허용 사용으로 처리하도록 수정
- 중복 방지 로직과 사용량 판정 로직의 주석/흐름 정리
- 관련 usage 테스트 재검증

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|   usage      |            |   [x]      |            |        |   [x]    |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```lua
if currentRemaining < usageBytes then
    return getResult('FAMILY_QUOTA_EXCEEDED', currentMonthly, false)
end

local newRemaining = redis.call('DECRBY', KEYS[2], usageBytes)
local newMonthly = redis.call('INCRBY', KEYS[3], usageBytes)

local status = 'NORMAL'
local ratio = 0

if totalLimit > 0 then
    ratio = newRemaining / totalLimit
end
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
