### PR TITLE
[DABOM-495] lib-kafka v1.0.1로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'com.github.da-bom:lib-kafka:v1.0.0'
+    implementation 'com.github.da-bom:lib-kafka:v1.0.1'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/src/main/java/com/project/domain/eventoutbox/entity/EventOutbox.java
+++ b/src/main/java/com/project/domain/eventoutbox/entity/EventOutbox.java
@@ -1,4 +1,4 @@
-package com.project.domain.usage.entity;
+package com.project.domain.eventoutbox.entity;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +14,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import com.project.common.util.BaseEntity;
-import com.project.domain.usage.enums.UsageOutboxStatus;
+import com.project.domain.eventoutbox.enums.EventOutboxStatus;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,7 +32,7 @@ import lombok.NoArgsConstructor;
         indexes = {
             @Index(name = "idx_usage_outbox_status_retry", columnList = "status, next_retry_at")
         })
-public class UsageEventOutbox extends BaseEntity {
+public class EventOutbox extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,7 +49,7 @@ public class UsageEventOutbox extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 30)
-    private UsageOutboxStatus status;
+    private EventOutboxStatus status;
 
     @Column(name = "payload_json", columnDefinition = "TEXT")
     private String payloadJson;
@@ -64,12 +64,12 @@ public class UsageEventOutbox extends BaseEntity {
     private String lastError;
 
     @Builder
-    private UsageEventOutbox(
+    private EventOutbox(
             Long id,
             String eventId,
             Long familyId,
             Long customerId,
-            UsageOutboxStatus status,
+            EventOutboxStatus status,
             String payloadJson,
             int retryCount,
             LocalDateTime nextRetryAt,

--- a/src/main/java/com/project/domain/eventoutbox/enums/EventOutboxStatus.java
+++ b/src/main/java/com/project/domain/eventoutbox/enums/EventOutboxStatus.java
@@ -1,0 +1,7 @@
+package com.project.domain.eventoutbox.enums;
+
+public enum EventOutboxStatus {
+    PUBLISH_PENDING,
+    SENT,
+    FAILED
+}

--- a/src/main/java/com/project/domain/eventoutbox/repository/EventOutboxRepository.java
+++ b/src/main/java/com/project/domain/eventoutbox/repository/EventOutboxRepository.java
@@ -1,4 +1,4 @@
-package com.project.domain.usage.repository;
+package com.project.domain.eventoutbox.repository;
 
 import java.util.Optional;
 
@@ -7,11 +7,11 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.project.domain.usage.entity.UsageEventOutbox;
+import com.project.domain.eventoutbox.entity.EventOutbox;
 
-public interface UsageEventOutboxRepository extends JpaRepository<UsageEventOutbox, Long> {
+public interface EventOutboxRepository extends JpaRepository<EventOutbox, Long> {
 
-    Optional<UsageEventOutbox> findByEventId(String eventId);
+    Optional<EventOutbox> findByEventId(String eventId);
 
     @Modifying
     @Query(
@@ -31,12 +31,12 @@ public interface UsageEventOutboxRepository extends JpaRepository<UsageEventOutb
     @Modifying
     @Query(
             """
-            update UsageEventOutbox o
+            update EventOutbox o
             set o.payloadJson = :payloadJson,
                 o.nextRetryAt = null,
                 o.lastError = null
             where o.eventId = :eventId
-              and o.status = com.project.domain.usage.enums.UsageOutboxStatus.PUBLISH_PENDING
+              and o.status = com.project.domain.eventoutbox.enums.EventOutboxStatus.PUBLISH_PENDING
             """)
     int refreshPendingPayload(
             @Param("eventId") String eventId, @Param("payloadJson") String payloadJson);
@@ -44,12 +44,12 @@ public interface UsageEventOutboxRepository extends JpaRepository<UsageEventOutb
     @Modifying
     @Query(
             """
-            update UsageEventOutbox o
-            set o.status = com.project.domain.usage.enums.UsageOutboxStatus.SENT,
+            update EventOutbox o
+            set o.status = com.project.domain.eventoutbox.enums.EventOutboxStatus.SENT,
                 o.nextRetryAt = null,
                 o.lastError = null
             where o.id = :outboxId
-              and o.status = com.project.domain.usage.enums.UsageOutboxStatus.PUBLISH_PENDING
+              and o.status = com.project.domain.eventoutbox.enums.EventOutboxStatus.PUBLISH_PENDING
             """)
     int markSentIfPending(@Param("outboxId") Long outboxId);
 }

--- a/src/main/java/com/project/domain/eventoutbox/service/EventOutboxService.java
+++ b/src/main/java/com/project/domain/eventoutbox/service/EventOutboxService.java
@@ -1,4 +1,4 @@
-package com.project.domain.usage.service.helper;
+package com.project.domain.eventoutbox.service;
 
 import java.util.Optional;
 
@@ -9,8 +9,8 @@ import com.dabom.messaging.kafka.error.NonRetryableKafkaMessageProcessingExcepti
 import com.dabom.messaging.kafka.event.dto.notification.NotificationPayload;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.domain.usage.enums.UsageOutboxStatus;
-import com.project.domain.usage.repository.UsageEventOutboxRepository;
+import com.project.domain.eventoutbox.enums.EventOutboxStatus;
+import com.project.domain.eventoutbox.repository.EventOutboxRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class UsageEventOutboxService {
+public class EventOutboxService {
 
-    private final UsageEventOutboxRepository usageEventOutboxRepository;
+    private final EventOutboxRepository eventOutboxRepository;
     private final ObjectMapper objectMapper;
 
     // notification 대상인 경우에만 PUBLISH_PENDING row를 보장한다.
@@ -32,12 +32,12 @@ public class UsageEventOutboxService {
         }
 
         String payloadJson = toJson(payload);
-        usageEventOutboxRepository.insertPublishPendingIgnore(
+        eventOutboxRepository.insertPublishPendingIgnore(
                 eventId, payload.familyId(), payload.customerId(), payloadJson);
-        usageEventOutboxRepository.refreshPendingPayload(eventId, payloadJson);
-        return usageEventOutboxRepository
+        eventOutboxRepository.refreshPendingPayload(eventId, payloadJson);
+        return eventOutboxRepository
                 .findByEventId(eventId)
-                .filter(row -> row.getStatus() == UsageOutboxStatus.PUBLISH_PENDING)
+                .filter(row -> row.getStatus() == EventOutboxStatus.PUBLISH_PENDING)
                 .map(
                         row ->
                                 new PendingNotificationDispatch(
@@ -48,9 +48,9 @@ public class UsageEventOutboxService {
     // eventId 기준으로 아직 발행되지 않은 notification payload를 찾는다.
     @Transactional(readOnly = true)
     public Optional<PendingNotificationDispatch> findPendingDispatchByEventId(String eventId) {
-        return usageEventOutboxRepository
+        return eventOutboxRepository
                 .findByEventId(eventId)
-                .filter(row -> row.getStatus() == UsageOutboxStatus.PUBLISH_PENDING)
+                .filter(row -> row.getStatus() == EventOutboxStatus.PUBLISH_PENDING)
                 .map(
                         row ->
                                 new PendingNotificationDispatch(
@@ -61,7 +61,7 @@ public class UsageEventOutboxService {
     // 발행 성공 시 Outbox 상태를 SENT로 변경한다.
     @Transactional
     public void markSent(Long outboxId) {
-        int updated = usageEventOutboxRepository.markSentIfPending(outboxId);
+        int updated = eventOutboxRepository.markSentIfPending(outboxId);
         if (updated == 0) {
             log.debug("Skip markSent because outbox is no longer pending. outboxId={}", outboxId);
         }

--- a/src/main/java/com/project/domain/usage/enums/UsageOutboxStatus.java
+++ b/src/main/java/com/project/domain/usage/enums/UsageOutboxStatus.java
@@ -1,7 +1,0 @@
-package com.project.domain.usage.enums;
-
-public enum UsageOutboxStatus {
-    PUBLISH_PENDING,
-    SENT,
-    FAILED
-}

--- a/src/main/java/com/project/domain/usage/service/UsageSyncServiceImpl.java
+++ b/src/main/java/com/project/domain/usage/service/UsageSyncServiceImpl.java
@@ -20,9 +20,9 @@ import com.dabom.messaging.kafka.metrics.KafkaMetrics;
 import com.project.common.config.TimeConfig;
 import com.project.common.util.LogSanitizer;
 import com.project.common.util.RedisKeyGenerator;
+import com.project.domain.eventoutbox.service.EventOutboxService;
 import com.project.domain.policy.helper.PolicyConstraintWarmupHelper;
 import com.project.domain.usage.service.dto.UsageUpdateResult;
-import com.project.domain.usage.service.helper.UsageEventOutboxService;
 import com.project.domain.usage.service.helper.UsageFamilyMembershipCacheHelper;
 import com.project.domain.usage.service.helper.UsageLuaExecutor;
 import com.project.domain.usage.service.helper.UsageNotificationPayloadMapper;
@@ -46,7 +46,7 @@ public class UsageSyncServiceImpl implements UsageSyncService {
     private final PolicyConstraintWarmupHelper policyConstraintWarmupHelper;
     private final UsageLuaExecutor usageLuaExecutor;
     private final UsagePersistService usagePersistService;
-    private final UsageEventOutboxService usageEventOutboxService;
+    private final EventOutboxService eventOutboxService;
     private final UsageProcessingDecisionMapper usageProcessingDecisionMapper;
     private final UsageNotificationPayloadMapper usageNotificationPayloadMapper;
     private final UsageNotificationPublisher usageNotificationPublisher;
@@ -167,7 +167,7 @@ public class UsageSyncServiceImpl implements UsageSyncService {
                 usageNotificationPayloadMapper.toNotificationPayload(
                         eventId, resolvedEventDateTime, payload, decision.notificationStatus());
 
-        usageEventOutboxService
+        eventOutboxService
                 .stageAfterRedisApplied(eventId, notificationPayload, true)
                 .ifPresent(this::publishAsync);
     }
@@ -214,17 +214,17 @@ public class UsageSyncServiceImpl implements UsageSyncService {
 
     // 이미 만들어진 pending notification이 있으면 다시 즉시 발행을 시도한다.
     private void dispatchPendingNotificationIfExists(String eventId) {
-        usageEventOutboxService.findPendingDispatchByEventId(eventId).ifPresent(this::publishAsync);
+        eventOutboxService.findPendingDispatchByEventId(eventId).ifPresent(this::publishAsync);
     }
 
     // notification은 비동기로 발행하고 성공 시에만 SENT로 마감한다.
-    private void publishAsync(UsageEventOutboxService.PendingNotificationDispatch pending) {
+    private void publishAsync(EventOutboxService.PendingNotificationDispatch pending) {
         usageNotificationPublisher
                 .publishAsync(pending.payload())
                 .whenComplete(
                         (SendResult<String, String> ignored, Throwable throwable) -> {
                             if (throwable == null) {
-                                usageEventOutboxService.markSent(pending.outboxId());
+                                eventOutboxService.markSent(pending.outboxId());
                                 return;
                             }
 

--- a/src/main/java/com/project/domain/usage/service/helper/UsageNotificationPayloadMapper.java
+++ b/src/main/java/com/project/domain/usage/service/helper/UsageNotificationPayloadMapper.java
@@ -84,7 +84,7 @@ public class UsageNotificationPayloadMapper {
         return new NotificationPayload(
                 usagePayload.familyId(),
                 usagePayload.customerId(),
-                NotificationType.BLOCKED,
+                NotificationType.CUSTOMER_BLOCKED,
                 "데이터 사용 차단",
                 message,
                 data);

--- a/src/test/java/com/project/domain/usage/service/UsageSyncServiceImplTest.java
+++ b/src/test/java/com/project/domain/usage/service/UsageSyncServiceImplTest.java
@@ -37,9 +37,9 @@ import com.dabom.messaging.kafka.event.dto.usage.UsagePayload;
 import com.dabom.messaging.kafka.metrics.KafkaMetrics;
 import com.project.common.util.LogSanitizer;
 import com.project.common.util.RedisKeyGenerator;
+import com.project.domain.eventoutbox.service.EventOutboxService;
 import com.project.domain.policy.helper.PolicyConstraintWarmupHelper;
 import com.project.domain.usage.service.dto.UsageUpdateResult;
-import com.project.domain.usage.service.helper.UsageEventOutboxService;
 import com.project.domain.usage.service.helper.UsageFamilyMembershipCacheHelper;
 import com.project.domain.usage.service.helper.UsageLuaExecutor;
 import com.project.domain.usage.service.helper.UsageNotificationPayloadMapper;
@@ -57,7 +57,7 @@ class UsageSyncServiceImplTest {
     @Mock private PolicyConstraintWarmupHelper policyConstraintWarmupHelper;
     @Mock private UsageLuaExecutor usageLuaExecutor;
     @Mock private UsagePersistService usagePersistService;
-    @Mock private UsageEventOutboxService usageEventOutboxService;
+    @Mock private EventOutboxService eventOutboxService;
     @Mock private UsageProcessingDecisionMapper usageProcessingDecisionMapper;
     @Mock private UsageNotificationPayloadMapper usageNotificationPayloadMapper;
     @Mock private UsageNotificationPublisher usageNotificationPublisher;
@@ -101,10 +101,10 @@ class UsageSyncServiceImplTest {
                         usageNotificationPayloadMapper.toNotificationPayload(
                                 any(), any(), any(), eq("WARNING_10")))
                 .willReturn(notificationPayload);
-        given(usageEventOutboxService.stageAfterRedisApplied(eventId, notificationPayload, true))
+        given(eventOutboxService.stageAfterRedisApplied(eventId, notificationPayload, true))
                 .willReturn(
                         Optional.of(
-                                new UsageEventOutboxService.PendingNotificationDispatch(
+                                new EventOutboxService.PendingNotificationDispatch(
                                         11L, notificationPayload)));
         given(usageNotificationPublisher.publishAsync(notificationPayload))
                 .willReturn(CompletableFuture.completedFuture(null));
@@ -132,7 +132,7 @@ class UsageSyncServiceImplTest {
 
         verify(usagePersistService).persistFromUsageEvent(eventId, eventTime, payload, "ALLOWED");
         verify(usageNotificationPublisher).publishAsync(notificationPayload);
-        verify(usageEventOutboxService).markSent(11L);
+        verify(eventOutboxService).markSent(11L);
     }
 
     @Test
@@ -195,10 +195,10 @@ class UsageSyncServiceImplTest {
                         usageNotificationPayloadMapper.toNotificationPayload(
                                 any(), any(), any(), eq("WARNING_10")))
                 .willReturn(notificationPayload);
-        given(usageEventOutboxService.stageAfterRedisApplied(eventId, notificationPayload, true))
+        given(eventOutboxService.stageAfterRedisApplied(eventId, notificationPayload, true))
                 .willReturn(
                         Optional.of(
-                                new UsageEventOutboxService.PendingNotificationDispatch(
+                                new EventOutboxService.PendingNotificationDispatch(
                                         21L, notificationPayload)));
         given(usageNotificationPublisher.publishAsync(notificationPayload))
                 .willReturn(CompletableFuture.completedFuture(null));
@@ -234,10 +234,10 @@ class UsageSyncServiceImplTest {
                         new UsageUpdateResult(
                                 5000L, 5000L, "NORMAL", 1000L, 0.1, 10000L, false, true));
         given(usageProcessingDecisionMapper.fromLuaStatus("NORMAL")).willReturn(decision);
-        given(usageEventOutboxService.findPendingDispatchByEventId(eventId))
+        given(eventOutboxService.findPendingDispatchByEventId(eventId))
                 .willReturn(
                         Optional.of(
-                                new UsageEventOutboxService.PendingNotificationDispatch(
+                                new EventOutboxService.PendingNotificationDispatch(
                                         31L, notificationPayload)));
         given(usageNotificationPublisher.publishAsync(notificationPayload))
                 .willReturn(CompletableFuture.completedFuture(null));
@@ -245,9 +245,9 @@ class UsageSyncServiceImplTest {
         usageSyncServiceImpl.syncUsage(eventId, eventTime, payload);
 
         verify(usagePersistService).persistFromUsageEvent(eventId, eventTime, payload, "ALLOWED");
-        verify(usageEventOutboxService, never()).stageAfterRedisApplied(any(), any(), anyBoolean());
+        verify(eventOutboxService, never()).stageAfterRedisApplied(any(), any(), anyBoolean());
         verify(usageNotificationPublisher).publishAsync(notificationPayload);
-        verify(usageEventOutboxService).markSent(31L);
+        verify(eventOutboxService).markSent(31L);
     }
 
     @Test
@@ -267,7 +267,7 @@ class UsageSyncServiceImplTest {
                         new UsageUpdateResult(
                                 5000L, 5000L, "APP_BLOCK", 1000L, 0.1, 10000L, false, false));
         given(usageProcessingDecisionMapper.fromLuaStatus("APP_BLOCK")).willReturn(decision);
-        given(usageEventOutboxService.findPendingDispatchByEventId(eventId))
+        given(eventOutboxService.findPendingDispatchByEventId(eventId))
                 .willReturn(Optional.empty());
 
         usageSyncServiceImpl.syncUsage(eventId, eventTime, payload);
@@ -275,7 +275,7 @@ class UsageSyncServiceImplTest {
         verify(usagePersistService).persistFromUsageEvent(eventId, eventTime, payload, "APP_BLOCK");
         verify(usageNotificationPayloadMapper, never())
                 .toNotificationPayload(any(), any(), any(), any());
-        verify(usageEventOutboxService, never()).stageAfterRedisApplied(any(), any(), anyBoolean());
+        verify(eventOutboxService, never()).stageAfterRedisApplied(any(), any(), anyBoolean());
         verify(usageNotificationPublisher, never()).publishAsync(any());
     }
 
@@ -296,7 +296,7 @@ class UsageSyncServiceImplTest {
                         new UsageUpdateResult(
                                 5000L, 5000L, "NORMAL", 1000L, 0.1, 10000L, false, false));
         given(usageProcessingDecisionMapper.fromLuaStatus("NORMAL")).willReturn(decision);
-        given(usageEventOutboxService.findPendingDispatchByEventId(eventId))
+        given(eventOutboxService.findPendingDispatchByEventId(eventId))
                 .willReturn(Optional.empty());
 
         usageSyncServiceImpl.syncUsage(eventId, eventTime, payload);
@@ -304,7 +304,7 @@ class UsageSyncServiceImplTest {
         verify(usagePersistService).persistFromUsageEvent(eventId, eventTime, payload, "ALLOWED");
         verify(usageNotificationPayloadMapper, never())
                 .toNotificationPayload(any(), any(), any(), any());
-        verify(usageEventOutboxService, never()).stageAfterRedisApplied(any(), any(), anyBoolean());
+        verify(eventOutboxService, never()).stageAfterRedisApplied(any(), any(), anyBoolean());
     }
 
     @Test

--- a/src/test/java/com/project/domain/usage/service/helper/EventOutboxServiceTest.java
+++ b/src/test/java/com/project/domain/usage/service/helper/EventOutboxServiceTest.java
@@ -22,15 +22,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dabom.messaging.kafka.event.dto.notification.NotificationPayload;
 import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.domain.usage.entity.UsageEventOutbox;
-import com.project.domain.usage.enums.UsageOutboxStatus;
-import com.project.domain.usage.repository.UsageEventOutboxRepository;
+import com.project.domain.eventoutbox.entity.EventOutbox;
+import com.project.domain.eventoutbox.enums.EventOutboxStatus;
+import com.project.domain.eventoutbox.repository.EventOutboxRepository;
+import com.project.domain.eventoutbox.service.EventOutboxService;
 
 @ExtendWith(MockitoExtension.class)
-class UsageEventOutboxServiceTest {
+class EventOutboxServiceTest {
 
-    @InjectMocks private UsageEventOutboxService usageEventOutboxService;
-    @Mock private UsageEventOutboxRepository usageEventOutboxRepository;
+    @InjectMocks private EventOutboxService eventOutboxService;
+    @Mock private EventOutboxRepository eventOutboxRepository;
     @Spy private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -39,33 +40,33 @@ class UsageEventOutboxServiceTest {
         NotificationPayload payload =
                 new NotificationPayload(
                         100L, 1L, NotificationType.THRESHOLD_ALERT, "title", "message", Map.of());
-        UsageEventOutbox pending =
-                UsageEventOutbox.builder()
+        EventOutbox pending =
+                EventOutbox.builder()
                         .id(10L)
                         .eventId("evt_2")
                         .familyId(100L)
                         .customerId(1L)
-                        .status(UsageOutboxStatus.PUBLISH_PENDING)
+                        .status(EventOutboxStatus.PUBLISH_PENDING)
                         .payloadJson(objectMapper.valueToTree(payload).toString())
                         .retryCount(0)
                         .build();
 
         given(
-                        usageEventOutboxRepository.insertPublishPendingIgnore(
+                        eventOutboxRepository.insertPublishPendingIgnore(
                                 eq("evt_2"), eq(100L), eq(1L), any(String.class)))
                 .willReturn(1);
-        given(usageEventOutboxRepository.refreshPendingPayload(eq("evt_2"), any(String.class)))
+        given(eventOutboxRepository.refreshPendingPayload(eq("evt_2"), any(String.class)))
                 .willReturn(1);
-        given(usageEventOutboxRepository.findByEventId("evt_2")).willReturn(Optional.of(pending));
+        given(eventOutboxRepository.findByEventId("evt_2")).willReturn(Optional.of(pending));
 
-        Optional<UsageEventOutboxService.PendingNotificationDispatch> dispatch =
-                usageEventOutboxService.stageAfterRedisApplied("evt_2", payload, true);
+        Optional<EventOutboxService.PendingNotificationDispatch> dispatch =
+                eventOutboxService.stageAfterRedisApplied("evt_2", payload, true);
 
         assertTrue(dispatch.isPresent());
         assertEquals(100L, dispatch.get().payload().familyId());
-        verify(usageEventOutboxRepository)
+        verify(eventOutboxRepository)
                 .insertPublishPendingIgnore(eq("evt_2"), eq(100L), eq(1L), any(String.class));
-        verify(usageEventOutboxRepository).refreshPendingPayload(eq("evt_2"), any(String.class));
+        verify(eventOutboxRepository).refreshPendingPayload(eq("evt_2"), any(String.class));
     }
 
     @Test
@@ -75,13 +76,13 @@ class UsageEventOutboxServiceTest {
                 new NotificationPayload(
                         100L, 1L, NotificationType.THRESHOLD_ALERT, "title", "message", Map.of());
 
-        Optional<UsageEventOutboxService.PendingNotificationDispatch> dispatch =
-                usageEventOutboxService.stageAfterRedisApplied("evt_3", payload, false);
+        Optional<EventOutboxService.PendingNotificationDispatch> dispatch =
+                eventOutboxService.stageAfterRedisApplied("evt_3", payload, false);
 
         assertTrue(dispatch.isEmpty());
-        verify(usageEventOutboxRepository, never())
+        verify(eventOutboxRepository, never())
                 .insertPublishPendingIgnore(any(), any(Long.class), any(Long.class), any());
-        verify(usageEventOutboxRepository, never()).refreshPendingPayload(any(), any());
+        verify(eventOutboxRepository, never()).refreshPendingPayload(any(), any());
     }
 
     @Test
@@ -95,20 +96,20 @@ class UsageEventOutboxServiceTest {
                         "title",
                         "message",
                         Map.of("threshold", 10));
-        UsageEventOutbox pending =
-                UsageEventOutbox.builder()
+        EventOutbox pending =
+                EventOutbox.builder()
                         .id(20L)
                         .eventId("evt_4")
                         .familyId(100L)
                         .customerId(1L)
-                        .status(UsageOutboxStatus.PUBLISH_PENDING)
+                        .status(EventOutboxStatus.PUBLISH_PENDING)
                         .payloadJson(objectMapper.valueToTree(payload).toString())
                         .retryCount(0)
                         .build();
-        given(usageEventOutboxRepository.findByEventId("evt_4")).willReturn(Optional.of(pending));
+        given(eventOutboxRepository.findByEventId("evt_4")).willReturn(Optional.of(pending));
 
-        Optional<UsageEventOutboxService.PendingNotificationDispatch> found =
-                usageEventOutboxService.findPendingDispatchByEventId("evt_4");
+        Optional<EventOutboxService.PendingNotificationDispatch> found =
+                eventOutboxService.findPendingDispatchByEventId("evt_4");
 
         assertTrue(found.isPresent());
         assertEquals(20L, found.get().outboxId());


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #58 
- jira: DABOM-495

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
lib-kafka v1.0.1에 새로 추가된 notificationType에 맞추기 위함

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->
lib-kafka v1.0.0에서 lib-kafka v1.0.1으로 버전업

-

## 📂 변경 범위

<!-- 변경된 도메인/레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
|    usage    |            |     [x]    |            |        |       |        |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
private NotificationPayload buildBlockedAlert(
            String eventId,
            LocalDateTime eventDateTime,
            UsagePayload usagePayload,
            String notificationStatus) {
        Map<String, Object> data =
                createBaseData(eventId, eventDateTime, usagePayload, notificationStatus);
        data.put("reason", notificationStatus);

        String message =
                switch (notificationStatus) {
                    case "MANUAL" -> "현재 데이터 사용이 관리자 설정으로 차단되었습니다.";
                    case "APP_BLOCK" -> buildAppBlockMessage(usagePayload.appId());
                    case "TIME_BLOCK" -> "현재 시간에는 데이터 사용이 제한됩니다.";
                    case "MONTHLY_LIMIT_EXCEEDED" -> "개인 월 사용량 한도를 초과했습니다.";
                    case "FAMILY_QUOTA_EXCEEDED" -> "가족 데이터 사용량을 모두 소진했습니다.";
                    default -> "현재 데이터 사용이 차단되었습니다.";
                };

        return new NotificationPayload(
                usagePayload.familyId(),
                usagePayload.customerId(),
                NotificationType.CUSTOMER_BLOCKED,
                "데이터 사용 차단",
                message,
                data);
    }
```
NotificationType 변경

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
